### PR TITLE
Add Make and Clang as build agent capabilities.

### DIFF
--- a/src/agent/environment.ts
+++ b/src/agent/environment.ts
@@ -151,5 +151,8 @@ export function getCapabilities(): cm.IStringDictionary {
     checkWhich(cap, 'mvn', 'maven');
     checkTool(cap, 'xcode-select', '-p', 'xcode');
 
+    checkWhich(cap, 'make');
+    checkWhich(cap, 'clang');
+
     return cap;
 }


### PR DESCRIPTION
Our team has a desire to include Make and Clang in the build agent's system capabilities to be used as demands from custom agent tasks.  By including a checkWhich for Make and Clang in the environment file at the location of the change, build agents will automatically pick up these features when the agent is configured.