### PR TITLE
Add glob to agent dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "adm-zip": "0.4.x",
     "async": "0.x",
+    "glob": "^5.0.3",
     "iniparser": "~1.0.5",
     "minimist": "^0.2.0",
     "nconf": "0.6.x",


### PR DESCRIPTION
This adds glob to the agent's dependencies.  It is initially used by the Xamarin Test Cloud task to search for .ipa's, etc.