### PR TITLE
some endpoints have no type information, skip those

### DIFF
--- a/src/agent/plugins/build/prepare.ts
+++ b/src/agent/plugins/build/prepare.ts
@@ -34,6 +34,10 @@ export function beforeJob(ctx: ctxm.JobContext, callback) {
     // TODO: support TfsVersionControl
     var invalidType: string;
     endpoints.every((endpoint) => {
+        if (!endpoint.type) {
+            return false;
+        }
+
         if (supported.indexOf(endpoint.type.toLowerCase()) < 0) {
             invalidType = endpoint.type;
             return false;
@@ -59,6 +63,9 @@ export function beforeJob(ctx: ctxm.JobContext, callback) {
     ctx.info('selectedRef: ' + selectedRef);
 
     var srcendpoints = endpoints.filter(function (endpoint) {
+        if (!endpoint.type) {
+            return false;
+        }
         return (supported.indexOf(endpoint.type.toLowerCase()) >= 0);
     });
 


### PR DESCRIPTION
If the endpoint doesn't have a type, the toLowerCase() call would fail.  Add an explicit check to guard this scenario.