### PR TITLE
Rename variable "arguments"

### DIFF
--- a/src/agent/definitions/toolrunner.d.ts
+++ b/src/agent/definitions/toolrunner.d.ts
@@ -20,6 +20,6 @@ export declare class ToolRunner extends events.EventEmitter {
     args: string[];
     silent: boolean;
     private _debug(message);
-    arg(arguments: any, raw: any): void;
+    arg(args: any, raw: any): void;
     exec(options: IExecOptions): Q.Promise<{}>;
 }

--- a/src/test/lib/gitrepo.ts
+++ b/src/test/lib/gitrepo.ts
@@ -22,16 +22,16 @@ export class GitRepo {
 	}
 
 	public commit(message: string, addModified: boolean, callback: (err:any) => void) {
-		var arguments = [];
-		arguments.push('commit');
-		arguments.push('-m');
-		arguments.push(message);
+		var args = [];
+		args.push('commit');
+		args.push('-m');
+		args.push(message);
 
 		if (addModified) {
-			arguments.push('-a');
+			args.push('-a');
 		}
 
-		this.execute(arguments, callback);
+		this.execute(args, callback);
 	}
 
 	private execute(parameters: string[], callback: (err:any) => void) {


### PR DESCRIPTION
In strict mode, the string "arguments" cannot be used as a variable.

Without this change, I can't compile on my linux ubuntu box:
[11:58:46] Compiling TypeScript files using tsc version 1.5.0
[11:58:50] [tsc] > /home/yacao/Projects/vso-agent/src/agent/definitions/toolrunner.d.ts(23,9): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
[11:58:50] [tsc] > /home/yacao/Projects/vso-agent/src/test/lib/gitrepo.ts(25,7): error TS1210: Invalid use of 'arguments'. Class definitions are automatically in strict mode.
[11:58:51] Failed to compile TypeScript: Error: tsc command has exited with code:2

With this change:
yacao@linbuild01[12:22]:~/Projects/vso-agent (users/yacao/fixargumentsvar)$ gulp
[12:23:36] Using gulpfile ~/Projects/vso-agent/gulpfile.js
[12:23:36] Starting 'clean'...
[12:23:36] Finished 'clean' after 100 ms
[12:23:36] Starting 'copy'...
[12:23:37] Finished 'copy' after 60 ms
[12:23:37] Starting 'build'...
[12:23:37] Compiling TypeScript files using tsc version 1.5.0
[12:23:42] Finished 'build' after 5.65 s
[12:23:42] Starting 'package'...
[12:23:42] Finished 'package' after 159 ms
[12:23:42] Starting 'tar'...
[12:23:43] Finished 'tar' after 284 ms
[12:23:43] Starting 'default'...
[12:23:43] Finished 'default' after 13 μs
