### PR TITLE
Consuming teamFoundationCollectionUri in Release extension to download build artifacts

### DIFF
--- a/src/agent/plugins/release/artifact/buildArtifact.ts
+++ b/src/agent/plugins/release/artifact/buildArtifact.ts
@@ -16,7 +16,7 @@ export class BuildArtifact implements rmInterfaces.IArtifact {
         var defer = Q.defer<void>();
         try {
             var buildDetails: releaseIfm.AgentTfsBuildArtifactDetails = JSON.parse(artifactDefinition.details, releaseCommon.reviver);
-            var serverUrl = context.jobInfo.jobMessage.environment.systemConnection.url;
+            var serverUrl = context.variables[common.vars.systemTfCollectionUri];
             var buildClient = new webapim.WebApi(serverUrl, context.jobInfo.systemAuthHandler).getQBuildApi();
             buildClient.getArtifacts(+artifactDefinition.version, buildDetails.project).then((buildArtifacts: buildIfm.BuildArtifact[]) => {
                 if (buildArtifacts.length === 0) {

--- a/src/agent/plugins/release/artifact/buildArtifactResolver.ts
+++ b/src/agent/plugins/release/artifact/buildArtifactResolver.ts
@@ -31,13 +31,14 @@ export class BuildArtifactResolver {
                     defer.reject(errorMessage);
                     return;
                 }
+                defer.resolve(null);
             }).fail((err) => {
                 defer.reject(err);
                 return;
             });
         }
         else if (buildArtifact.resource.type.toLowerCase() === 'container') {
-            var serverUrl = context.jobInfo.jobMessage.environment.systemConnection.url;
+            var serverUrl = context.variables[common.vars.systemTfCollectionUri];
             var buildClient = new webapim.WebApi(serverUrl, context.jobInfo.systemAuthHandler).getBuildApi();
             var zipFilePath = artifactDownloadFolder + '.zip';
             buildClient.getArtifactContentZip(buildId, buildArtifact.name, buildDetails.project, (err, statusCode, res) => {

--- a/src/agent/vsoworker.ts
+++ b/src/agent/vsoworker.ts
@@ -109,7 +109,7 @@ export function run(msg: cm.IWorkerMessage, consoleOutput: boolean,
         trace.state('msg:', msg);
 
         var agentUrl = hostContext.config.settings.serverUrl;
-        var taskUrl = job.environment.variables[cm.vars.systemTfCollectionUri];
+        var taskUrl = job.environment.systemConnection.url;
         
         var jobInfo = cm.jobInfoFromJob(job, systemAuthHandler);
         var serviceChannel: cm.IServiceChannel = createFeedbackChannel(agentUrl, taskUrl, jobInfo, hostContext);


### PR DESCRIPTION
Also,
Agent will use the url from systemconnection service endpoint and not the variable to talk to distributedTask
This is because after m89 deployment the service will start sending down the collectionUri variable by setting the url to tfs url.