### PR TITLE
fix #113

### DIFF
--- a/src/agent/plugins/build/sourceMappings.ts
+++ b/src/agent/plugins/build/sourceMappings.ts
@@ -96,7 +96,9 @@ export class SourceMappings {
         };
         
         shell.mkdir('-p', this.sourceMappingRootPath);
-        return utilm.getOrCreateObjectFromFile(this.sourceTrackingPath, newTrk);
+        return utilm.getOrCreateObjectFromFile(this.sourceTrackingPath, newTrk).then((result: utilm.GetOrCreateResult<ISourceTracking>) => {
+            return result.result;
+        });
     }
     
     public incrementSourceTracking(): Q.Promise<ISourceTracking> {
@@ -191,11 +193,12 @@ export class SourceMappings {
         this.updateSourceMappingPaths(expectedMap, trk);
         
         return utilm.getOrCreateObjectFromFile(srcMapPath, expectedMap)
-        .then((currMap: ISourceMapping) => {
+        .then((result: utilm.GetOrCreateResult<ISourceMapping>) => {
+            var currMap: ISourceMapping = result.result;
             trace.state('curr.hashKey', currMap.hashKey);
             trace.state('expected.hashKey', expectedMap.hashKey);
             
-            if (currMap.hashKey !== expectedMap.hashKey) {
+            if (result.created || currMap.hashKey !== expectedMap.hashKey) {
                 trace.write('creating new source folder');
                 return this.createNewSourceFolder(currMap);
             }

--- a/src/agent/utilities.ts
+++ b/src/agent/utilities.ts
@@ -10,6 +10,11 @@ import fs = require('fs');
 var shell = require('shelljs');
 var path = require('path');
 
+export interface GetOrCreateResult<T> {
+    created: boolean;
+    result: T;
+}
+
 // TODO: offer these module level context-less helper functions in utilities below
 export function ensurePathExists(path: string): Q.Promise<void> {
     var defer = Q.defer<void>();
@@ -100,8 +105,8 @@ export function objectFromFile(filePath: string, defObj?:any): Q.Promise<any> {
     return defer.promise;
 }
 
-export function getOrCreateObjectFromFile(filePath: string, defObj:any): Q.Promise<any> {
-    var defer = Q.defer<any>();
+export function getOrCreateObjectFromFile<T>(filePath: string, defObj: T): Q.Promise<GetOrCreateResult<T>> {
+    var defer = Q.defer<GetOrCreateResult<T>>();
     
     fs.exists(filePath, (exists) => {
         if (!exists) {
@@ -110,7 +115,10 @@ export function getOrCreateObjectFromFile(filePath: string, defObj:any): Q.Promi
                     defer.reject(new Error('Could not save to file (' + filePath + '): ' + err.message));
                 }
                 else {
-                    defer.resolve(defObj);
+                    defer.resolve({
+                        created: true,
+                        result: defObj
+                    });
                 }
             });
         }
@@ -121,7 +129,10 @@ export function getOrCreateObjectFromFile(filePath: string, defObj:any): Q.Promi
                 }
                 else {
                     var obj: any = JSON.parse(contents.toString());
-                    defer.resolve(obj);
+                    defer.resolve({
+                        created: false,
+                        result: obj
+                    });
                 }
             });            
         }


### PR DESCRIPTION
getOrCreateObjectFromFile now returns { boolean, T } where the boolean indicates whether the file was created. processSourceMapping creates a new source folder if the file was created, regardless of whether the hash is different