### PR TITLE
address plurality of sources for vso vs local

### DIFF
--- a/src/agent/common.ts
+++ b/src/agent/common.ts
@@ -70,6 +70,7 @@ export class AutomationVariables {
     public static buildSourceVersion = 'build.sourceVersion';
     public static buildSourceBranch = 'build.sourceBranch';
     public static buildSourceBranchName = 'build.sourceBranchName';
+    public static buildContainerId = 'build.containerId';
     
     //
     // Common Variables

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -26,11 +26,11 @@ function ensureTrace(writer: cm.ITraceWriter) {
 }
 
 export class WellKnownVariables {
-    public static sourceFolder = "build.sourceDirectory";
-    public static stagingFolder = "build.stagingdirectory";
-    public static buildId = "build.buildId";
-    public static projectId = "system.teamProjectId";
-    public static containerId = "build.containerId";
+    public static sourceFolder = cm.vars.buildSourcesDirectory;
+    public static stagingFolder = cm.vars.buildStagingDirectory;
+    public static buildId = cm.vars.buildId;
+    public static projectId = cm.vars.systemTeamProjectId;
+    public static containerId = cm.vars.buildContainerId;
 }
 
 export class Context extends events.EventEmitter {

--- a/src/test/tasks/Xcode/1.0.2/xcodebuild.js
+++ b/src/test/tasks/Xcode/1.0.2/xcodebuild.js
@@ -14,7 +14,7 @@ exports.execute = function(ctx, callback) {
 	var xcbpath = which('xcodebuild');
 	ctx.verbose('using xcodebuild: ' + xcbpath);
 
-	var repoPath = ctx.variables['build.sourceDirectory'];
+	var repoPath = ctx.variables['build.sourcesDirectory'];
 
 	//----------------------------------------------------------------------
 	// Input Validation/Feedback


### PR DESCRIPTION
This fixes the use of $(Build.SourcesDirectory) for the agent as it was expecting 'source' vs. 'sources' for the remote agent.