### PR TITLE
Adding system.defaultworkingdirectory as a variable

### DIFF
--- a/src/agent/common.ts
+++ b/src/agent/common.ts
@@ -40,7 +40,7 @@ export class AutomationVariables {
     public static systemTfCollectionUri = 'system.teamFoundationCollectionUri';
     public static systemTeamProjectId = 'system.teamProjectId';
     public static systemDebug = 'system.debug';
-    public static defaultWorkingDirectory = 'system.defaultworkingdirectory';
+    public static defaultWorkingDirectory = 'system.defaultWorkingDirectory';
     
     //
     // Agent Variables

--- a/src/agent/common.ts
+++ b/src/agent/common.ts
@@ -40,6 +40,7 @@ export class AutomationVariables {
     public static systemTfCollectionUri = 'system.teamFoundationCollectionUri';
     public static systemTeamProjectId = 'system.teamProjectId';
     public static systemDebug = 'system.debug';
+    public static defaultWorkingDirectory = 'system.defaultworkingdirectory';
     
     //
     // Agent Variables

--- a/src/agent/plugins/release/prepare.ts
+++ b/src/agent/plugins/release/prepare.ts
@@ -100,12 +100,16 @@ export function createHash(teamProject: string, releaseDefinitionName: string): 
 }
 
 export function setAndLogLocalVariables(context: common.IExecutionContext, artifactsFolder: string, artifactDefinitions: releaseIfm.AgentArtifactDefinition[]): void {
+    // Remove after M90 as it is set by service
     if (artifactDefinitions.length === 1 && artifactDefinitions[0].artifactType === releaseIfm.AgentArtifactType.Build) {
-        context.variables[releaseCommon.releaseVars.buildId] = artifactDefinitions[0].version;
+        if (!context.variables[releaseCommon.releaseVars.buildId]) {
+            context.variables[releaseCommon.releaseVars.buildId] = artifactDefinitions[0].version;
+        }
     }
 
     context.variables[releaseCommon.releaseVars.agentReleaseDirectory] = artifactsFolder;
     context.variables[releaseCommon.releaseVars.systemArtifactsDirectory] = artifactsFolder;
+    context.variables[common.AutomationVariables.defaultWorkingDirectory] = artifactsFolder;
 
     context.verbose('Environment variables available are below.  Note that these environment variables can be referred to in the task (in the ReleaseDefinition) by replacing "_" with "." e.g. AGENT_WORKINGDIRECTORY environment variable can be referenced using Agent.WorkingDirectory in the ReleaseDefinition:' + JSON.stringify(context.variables, null, 2));
 }

--- a/src/test/releasePlugin.ts
+++ b/src/test/releasePlugin.ts
@@ -69,6 +69,7 @@ describe('Release plugin before job', () => {
 
         assert(context.variables[releaseCommon.releaseVars.agentReleaseDirectory] === folder, 'Agent release directory should be set as a variable');
         assert(context.variables[releaseCommon.releaseVars.systemArtifactsDirectory] === folder, 'System artifacts directory should be set as variable');
+        assert(context.variables[releaseCommon.releaseVars.systemArtifactsDirectory] === folder, 'System default working directory should be set as variable');
         done();
     });
 


### PR DESCRIPTION
Fixing the build.buildId variable as well. We will not override the value that is set by service