### PR TITLE
Add support for nested variables

### DIFF
--- a/src/agent/extensions.ts
+++ b/src/agent/extensions.ts
@@ -31,13 +31,20 @@ String.prototype.isEqual = function(ignoreCase, str) {
 // "This $(somevar) and $(somevar2) replaced".replaceVars({somevar:someval, somevar2:someval2})
 //
 String.prototype.replaceVars = function (vars) {
-    return this.replace(/\$\(([^\)]+)\)/g, function (placeholder, variable) {
-      var lowerVar = variable.toLowerCase();
-      if (vars[lowerVar]) {
-        return vars[lowerVar];
-      }
-      else {
+    function recursiveResolve(inputValue, stack) {
+      return inputValue.replace(/\$\(([^\)]+)\)/g, function (placeholder, variable) {
+        var lowerVar = variable.toLowerCase();
+        
+        if (stack.indexOf(lowerVar) === -1 && vars[lowerVar]) {
+          stack.push(lowerVar);
+          var replacement = recursiveResolve(vars[lowerVar], stack);
+          stack.pop();
+          return replacement;
+        }
+        
         return placeholder;
-      }
-    });
+      });
+    }
+    
+    return recursiveResolve(this, []);
 };


### PR DESCRIPTION
Currently, variable replacement uses a single pass to resolve values. This prevents
users from using variable reverences in their values.  This change adds support for
chained variables while preventing circular reference looping.

Given:
one: 'one'
two: '$(one) two'
three: '$(two) $(three)'
four: '$(three) four'
serverName: 'super$(service)-$(environment)'
service: 'Api'
environemnt: 'prod'

Then:
'$(one)' => 'one'
'$(two)' => 'one two'
'$(three)' => 'one two $(three)'
'$(four)' => 'one two $(three) four'
'$(serverName)-1' => 'superApi-prod-1'