### PR TITLE
Message listener now bails when it gets 4XX response from server

### DIFF
--- a/src/agent/messagelistener.ts
+++ b/src/agent/messagelistener.ts
@@ -51,6 +51,16 @@ export class MessageListener extends events.EventEmitter {
                 this.getMessages(callback, onError);
                 return;
             }
+            
+            // bail on any 400 error code
+            if (statusCode >= 400 && statusCode < 500) {
+                if (err && err.message) {
+                    onError(new Error('Unable to receive messages: ' + err.message));
+                } else {
+                    onError(new Error('Unable to receive messages: ' + statusCode));
+                }
+                return;
+            }
 
             this.emit('info', 'working status code: ' + statusCode);
 


### PR DESCRIPTION
A few of the "failed commands" we're seeing on hosted are being caused by the agent not killing itself if it receives any 400 level http response from the server when attempting to get a message.

I still left the previous handling alone so that the behavior stays the same.