### PR TITLE
Test Run Title and Publish Test Attachments

### DIFF
--- a/src/agent/commands/results.publish.ts
+++ b/src/agent/commands/results.publish.ts
@@ -37,9 +37,9 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
 
         var platform: string = this.command.properties['platform'];
         var config : string = this.command.properties['config'];
-		var runTitle : string = this.command.properties['runTitle'];
-		var fileNumber : string = this.command.properties['fileNumber'];
-		var publishRunAttachments : boolean = (this.command.properties['publishRunAttachments'] === "true");
+        var runTitle : string = this.command.properties['runTitle'];
+        var fileNumber : string = this.command.properties['fileNumber'];
+        var publishRunAttachments : boolean = (this.command.properties['publishRunAttachments'] === "true");
         var command = this.command;
         
         var testRunContext: trp.TestRunContext = {
@@ -49,9 +49,9 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
             releaseUri: this.executionContext.variables["release.releaseUri"],
             platform: platform,
             config: config,
-			runTitle: runTitle,
-			fileNumber: fileNumber,
-			publishRunAttachments: publishRunAttachments
+            runTitle: runTitle,
+            fileNumber: fileNumber,
+            publishRunAttachments: publishRunAttachments
         };
 
         var reader;

--- a/src/agent/commands/results.publish.ts
+++ b/src/agent/commands/results.publish.ts
@@ -85,4 +85,3 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
         return defer.promise;
     }   
 }
-

--- a/src/agent/commands/results.publish.ts
+++ b/src/agent/commands/results.publish.ts
@@ -64,8 +64,8 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
         else if (resultType == "xunit") {
             reader = new trr.XUnitResultReader();
         }
-        else {
-            this.command.warning("Test results of format '" + resultType + "'' are not supported by the VSTS/TFS OSX and Linux build agent");
+        else if (resultType == "vstest") {
+            this.command.warning("Test results of format '" + resultType + "'' are not supported on this build agent");
         }
 
         if (reader != null) {

--- a/src/agent/commands/results.publish.ts
+++ b/src/agent/commands/results.publish.ts
@@ -37,6 +37,9 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
 
         var platform: string = this.command.properties['platform'];
         var config : string = this.command.properties['config'];
+		var runTitle : string = this.command.properties['runTitle'];
+		var fileNumber : string = this.command.properties['fileNumber'];
+		var publishRunAttachments : boolean = (this.command.properties['publishRunAttachments'] === "true");
         var command = this.command;
         
         var testRunContext: trp.TestRunContext = {
@@ -45,7 +48,10 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
             releaseEnvironmentUri: this.executionContext.variables["release.environmentUri"],
             releaseUri: this.executionContext.variables["release.releaseUri"],
             platform: platform,
-            config: config
+            config: config,
+			runTitle: runTitle,
+			fileNumber: fileNumber,
+			publishRunAttachments: publishRunAttachments
         };
 
         var reader;
@@ -59,12 +65,11 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
             reader = new trr.XUnitResultReader();
         }
         else {
-            this.command.warning("Test results of format '" + resultType + "'' are not supported by the VSO/TFS OSX and Linux build agent");
+            this.command.warning("Test results of format '" + resultType + "'' are not supported by the VSTS/TFS OSX and Linux build agent");
         }
 
         if (reader != null) {
             var testRunPublisher = new trp.TestRunPublisher(this.executionContext.service, command, teamProject, testRunContext, reader);
-
             testRunPublisher.publishTestRun(resultFilePath).then(function (createdTestRun) {
                 defer.resolve(null);
             })

--- a/src/agent/testresultreader.ts
+++ b/src/agent/testresultreader.ts
@@ -10,7 +10,7 @@ var Q = require('q');
 
 export class JUnitResultReader implements trp.IResultReader {
     
-	public readResults(file: string, runContext: trp.TestRunContext) : Q.Promise<ifm.TestRunWithResults> {
+    public readResults(file: string, runContext: trp.TestRunContext) : Q.Promise<ifm.TestRunWithResults> {
         return new ResultReader("junit").readResults(file, runContext);
     }
           
@@ -22,7 +22,7 @@ export class JUnitResultReader implements trp.IResultReader {
 //-----------------------------------------------------
 export class NUnitResultReader implements trp.IResultReader {
     
-	public readResults(file: string, runContext: trp.TestRunContext) : Q.Promise<ifm.TestRunWithResults> {
+    public readResults(file: string, runContext: trp.TestRunContext) : Q.Promise<ifm.TestRunWithResults> {
         return  new ResultReader("nunit").readResults(file, runContext);
     }    
 
@@ -30,7 +30,7 @@ export class NUnitResultReader implements trp.IResultReader {
 
 export class XUnitResultReader implements trp.IResultReader {
 
-	public readResults(file: string, runContext: trp.TestRunContext): Q.Promise<ifm.TestRunWithResults> {
+    public readResults(file: string, runContext: trp.TestRunContext): Q.Promise<ifm.TestRunWithResults> {
         return new ResultReader("xunit").readResults(file, runContext);
     }
 
@@ -132,13 +132,13 @@ export class ResultReader {
         var runTitle = runContext.runTitle;
         var fileNumber = runContext.fileNumber;
         var fileName;
-		
+        
         //Getting the file name for naming the test run
         if (file && 0 !== file.length) {
             // This handles both windows and mac os file formats to extract the file name
             fileName = file.split('\\').pop().split('/').pop();
         }
-		
+        
 
         //init test run summary - runname, host, start time, run duration
         var runSummary = new TestSuiteSummary();
@@ -180,7 +180,7 @@ export class ResultReader {
 
         var completedDate = runSummary.timeStamp;
         completedDate.setSeconds(runSummary.timeStamp.getSeconds() + runSummary.duration);
-		
+        
         //create test run data
         var testRun = <testifm.RunCreateModel>{
             name: runSummary.name,
@@ -232,7 +232,7 @@ export class ResultReader {
         if (rootNode.attributes().time) {
             totalRunDuration = parseFloat(rootNode.attributes().time); //in seconds
         }
-		
+        
         //find test case nodes in JUnit result xml
         var testResults = [];
 
@@ -320,7 +320,7 @@ export class ResultReader {
         var releaseEnvironmentUri = runContext.releaseEnvironmentUri;
         var runTitle = runContext.runTitle;
         var fileNumber = runContext.fileNumber;		
-		
+        
         //read test run summary - runname, host, start time, run duration
         var runName = this.runTitleNunitAndXunit(runTitle, fileNumber, "NUnit");
         var runStartTime = new Date();
@@ -671,6 +671,3 @@ export class ResultReader {
     }
 
 }
-
-
-

--- a/src/agent/testresultreader.ts
+++ b/src/agent/testresultreader.ts
@@ -58,14 +58,14 @@ export class TestSuiteSummary {
 
 export class ResultReader {
 
-	constructor(readerType: string) {
+    constructor(readerType: string) {
         this.type = readerType;
-	}
-	
-    private type: string;	
+    }
 
-    public readResults(file: string, runContext: trp.TestRunContext) : Q.Promise<ifm.TestRunWithResults> {
-        var defer = Q.defer(); 
+    private type: string;
+
+    public readResults(file: string, runContext: trp.TestRunContext): Q.Promise<ifm.TestRunWithResults> {
+        var defer = Q.defer();
         var _this = this;
 
         utilities.readFileContents(file, "utf-8").then(function (contents) {
@@ -75,27 +75,27 @@ export class ResultReader {
             defer.resolve(testRun);
         }).fail(function (err) {
             defer.reject(err);
-        });        
+        });
 
         return defer.promise;
     }
 
-    private readTestRunData(contents: string, runContext: trp.TestRunContext, file: string) : Q.Promise<ifm.TestRunWithResults> {
-        var defer = Q.defer(); 
-      
-        var testRun2 : ifm.TestRunWithResults;
+    private readTestRunData(contents: string, runContext: trp.TestRunContext, file: string): Q.Promise<ifm.TestRunWithResults> {
+        var defer = Q.defer();
+
+        var testRun2: ifm.TestRunWithResults;
         var _this = this;
 
         xmlreader.read(contents, function (err, res) {
-            if(err) {
+            if (err) {
                 defer.reject(err);
-            } 
+            }
             else {
                 try {
                     testRun2 = _this.parseXml(res, runContext, file);
                     defer.resolve(testRun2);
                 }
-                catch(ex) {
+                catch (ex) {
                     defer.reject(ex);
                 }
             }
@@ -105,10 +105,10 @@ export class ResultReader {
     }
 
     private parseXml(res, runContext, file) {
-        if(this.type == "junit") {
+        if (this.type == "junit") {
             return this.parseJUnitXml(res, runContext, file);
         }
-        else if(this.type == "nunit") {
+        else if (this.type == "nunit") {
             return this.parseNUnitXml(res, runContext);
         }
         else if (this.type == "xunit") {
@@ -118,82 +118,71 @@ export class ResultReader {
             return null;
         }
 
-    }    
+    }
 
     private parseJUnitXml(res, runContext, file) {
-		
-        var testRun2 : ifm.TestRunWithResults;
+
+        var testRun2: ifm.TestRunWithResults;
         var buildId = runContext.buildId;
         var buildRequestedFor = runContext.requestedFor;
         var platform = runContext.platform;
         var config = runContext.config;
         var releaseUri = runContext.releaseUri;
         var releaseEnvironmentUri = runContext.releaseEnvironmentUri;
-		var runTitle = runContext.runTitle;
-		var fileNumber = runContext.fileNumber;
-		var fileName;
+        var runTitle = runContext.runTitle;
+        var fileNumber = runContext.fileNumber;
+        var fileName;
 		
-		//Getting the file name for naming the test run
-		if (file && 0 !== file.length) {
-			// This handles both windows and mac os file formats to extract the file name
-			fileName = file.split('\\').pop().split('/').pop();
-		}
+        //Getting the file name for naming the test run
+        if (file && 0 !== file.length) {
+            // This handles both windows and mac os file formats to extract the file name
+            fileName = file.split('\\').pop().split('/').pop();
+        }
 		
 
         //init test run summary - runname, host, start time, run duration
         var runSummary = new TestSuiteSummary();
-        
-        if(res.testsuites) {
-			var testSuitesNode = res.testsuites.at(0);
+
+        if (res.testsuites) {
+            var testSuitesNode = res.testsuites.at(0);
         }
 
-        if(testSuitesNode) {
-			if(testSuitesNode.testsuite) {
-				var numTestSuites = testSuitesNode.testsuite.count();
-                for(var n = 0; n < numTestSuites; n ++) {
+        if (testSuitesNode) {
+            if (testSuitesNode.testsuite) {
+                var numTestSuites = testSuitesNode.testsuite.count();
+                for (var n = 0; n < numTestSuites; n++) {
                     var testSuiteSummary = this.readTestSuiteJUnitXml(testSuitesNode.testsuite.at(n), buildRequestedFor, runTitle, fileNumber, fileName);
                     runSummary.duration += testSuiteSummary.duration;
                     runSummary.addResults(testSuiteSummary.results);
                     runSummary.host = testSuiteSummary.host;
-					runSummary.name = testSuiteSummary.name;
-					
-                    if(runSummary.timeStamp > testSuiteSummary.timeStamp) {
+                    runSummary.name = testSuiteSummary.name;
+
+                    if (runSummary.timeStamp > testSuiteSummary.timeStamp) {
                         runSummary.timeStamp = testSuiteSummary.timeStamp; //use earlier Date for run start time
                     }
                 }
-				
-				if (!(runTitle && 0 !== runTitle.length)) {
-					if(numTestSuites > 1) {
-						if (fileName && 0 !== fileName.length) {
-							runSummary.name = "JUnit" + fileName;							
-						}
-						else {
-							if (fileNumber == 0)
-							{
-								runSummary.name = "JUnit";
-							}
-							else {
-								runSummary.name = "JUnit" + fileNumber;
-							}
-						}
-					}
-				}
+
+                if (!(runTitle && 0 !== runTitle.length)) {
+                    if (numTestSuites > 1) {
+                        runSummary.name = this.runTitleJunit(fileName, parseInt(fileNumber));
+                    }
+                }
             }
         }
         else {
-            if(res.testsuite) {
+            if (res.testsuite) {
                 var testSuiteNode = res.testsuite.at(0);
             }
-            if(testSuiteNode) {
+            if (testSuiteNode) {
                 runSummary = this.readTestSuiteJUnitXml(testSuiteNode, buildRequestedFor, runTitle, fileNumber, fileName);
             }
-        }            
+        }
 
         var completedDate = runSummary.timeStamp;
         completedDate.setSeconds(runSummary.timeStamp.getSeconds() + runSummary.duration);
 		
-		//create test run data
-        var testRun =    <testifm.RunCreateModel>{
+        //create test run data
+        var testRun = <testifm.RunCreateModel>{
             name: runSummary.name,
             state: "InProgress",
             automated: true,
@@ -216,70 +205,54 @@ export class ResultReader {
     private readTestSuiteJUnitXml(rootNode, buildRequestedFor, runTitle, fileNumber, fileName) {
         var testSuiteSummary = new TestSuiteSummary();
         var totalRunDuration = 0;
-        var totalTestCaseDuration = 0;		
-		
-		if (runTitle && 0 !== runTitle.length) {	
-			if (fileNumber == 0) {
-				testSuiteSummary.name = runTitle;
-			}
-			else {
-				testSuiteSummary.name = runTitle + " " + fileNumber;
-			}
-		}
-        else if(rootNode.attributes().name) {
+        var totalTestCaseDuration = 0;
+
+        if (runTitle && 0 !== runTitle.length) {
+            testSuiteSummary.name = this.fileNumberToTitle(runTitle, parseInt(fileNumber));
+        }
+        else if (rootNode.attributes().name) {
             testSuiteSummary.name = rootNode.attributes().name;
         }
-		else {
-			if (fileName && 0 !== fileName.length) {				
-				testSuiteSummary.name = "JUnit" + fileName;							
-			}
-			else {
-				if (fileNumber == 0)
-				{
-					testSuiteSummary.name = "JUnit";
-				}
-				else {
-					testSuiteSummary.name = "JUnit " + fileNumber;
-				}				
-			}
-		}
+        else {
+            testSuiteSummary.name = this.runTitleJunit(fileName, parseInt(fileNumber));
+        }
 
-        if(rootNode.attributes().hostname) {
+        if (rootNode.attributes().hostname) {
             testSuiteSummary.host = rootNode.attributes().hostname;
         }
 
         //assume runtimes from xml are current local time since timezone information is not in the xml. If xml date > current local date, fall back to local
-        if(rootNode.attributes().timestamp) {
+        if (rootNode.attributes().timestamp) {
             var timestampFromXml = new Date(rootNode.attributes().timestamp);
-            if(timestampFromXml < new Date()) {
+            if (timestampFromXml < new Date()) {
                 testSuiteSummary.timeStamp = timestampFromXml;
-            }                    
+            }
         }
 
-        if(rootNode.attributes().time) {
+        if (rootNode.attributes().time) {
             totalRunDuration = parseFloat(rootNode.attributes().time); //in seconds
         }
 		
-		//find test case nodes in JUnit result xml
+        //find test case nodes in JUnit result xml
         var testResults = [];
 
-        for(var i = 0; i < rootNode.testcase.count(); i ++) {
+        for (var i = 0; i < rootNode.testcase.count(); i++) {
             var testCaseNode = rootNode.testcase.at(i);
 
             //testcase name and type
             var testName = "";
-            if(testCaseNode.attributes().name) {
-                testName = testCaseNode.attributes().name;                    
-            } 
+            if (testCaseNode.attributes().name) {
+                testName = testCaseNode.attributes().name;
+            }
 
             var testStorage = "";
-            if(testCaseNode.attributes().classname) {
+            if (testCaseNode.attributes().classname) {
                 testStorage = testCaseNode.attributes().classname;
             }
 
             //testcase duration
             var testCaseDuration = 0; //in seconds
-            if(testCaseNode.attributes().time) {
+            if (testCaseNode.attributes().time) {
                 testCaseDuration = parseFloat(testCaseNode.attributes().time);
                 totalTestCaseDuration += testCaseDuration;
             }
@@ -288,7 +261,7 @@ export class ResultReader {
             var outcome = "Passed";
             var errorMessage = "";
             var stackTrace = "";
-            if(testCaseNode.failure) {
+            if (testCaseNode.failure) {
                 outcome = "Failed";
                 if (testCaseNode.failure.text) {
                     stackTrace = testCaseNode.failure.text();
@@ -297,7 +270,7 @@ export class ResultReader {
                     errorMessage = testCaseNode.failure.attributes().message;
                 }
             }
-            else if(testCaseNode.error) {
+            else if (testCaseNode.error) {
                 outcome = "Failed";
                 if (testCaseNode.error.text) {
                     stackTrace = testCaseNode.error.text();
@@ -311,14 +284,14 @@ export class ResultReader {
                 errorMessage = testCaseNode.skipped.text();
             }
 
-            var testResult : testifm.TestResultCreateModel = <testifm.TestResultCreateModel> {
+            var testResult: testifm.TestResultCreateModel = <testifm.TestResultCreateModel>{
                 state: "Completed",
                 computerName: testSuiteSummary.host,
                 testCasePriority: "1",
                 automatedTestName: testName,
                 automatedTestStorage: testStorage,
                 automatedTestType: "JUnit",
-                owner: { id: buildRequestedFor }, 
+                owner: { id: buildRequestedFor },
                 runBy: { id: buildRequestedFor },
                 testCaseTitle: testName,
                 outcome: outcome,
@@ -326,71 +299,55 @@ export class ResultReader {
                 durationInMs: "" + Math.round(testCaseDuration * 1000), //convert to milliseconds and round to nearest whole number since server can't handle decimals for test case duration
                 stackTrace: stackTrace
             };
-                
-            testResults.push(testResult);
-        }    
 
-        if(totalRunDuration < totalTestCaseDuration) {
+            testResults.push(testResult);
+        }
+
+        if (totalRunDuration < totalTestCaseDuration) {
             totalRunDuration = totalTestCaseDuration; //run duration may not be set in the xml, so use the testcase duration
         }
         testSuiteSummary.duration = totalRunDuration;
         testSuiteSummary.addResults(testResults);
-		return testSuiteSummary;
+        return testSuiteSummary;
     }
 
     private parseNUnitXml(res, runContext) {
         var testRun2: ifm.TestRunWithResults;
-        
+
         var buildId = runContext.buildId;
         var buildRequestedFor = runContext.requestedFor;
         var releaseUri = runContext.releaseUri;
         var releaseEnvironmentUri = runContext.releaseEnvironmentUri;
-		var runTitle = runContext.runTitle;
-		var fileNumber = runContext.fileNumber;
-		var runName;
+        var runTitle = runContext.runTitle;
+        var fileNumber = runContext.fileNumber;		
 		
         //read test run summary - runname, host, start time, run duration
-		if (runTitle && 0 !== runTitle.length) {
-			if (fileNumber == 0){
-				runName = runTitle;
-			}
-			else {
-				runName = runTitle + " " + fileNumber;
-			}
-		}
-		else {
-			if (fileNumber == 0){
-				runName = "NUnit";
-			}
-			else {
-				runName = "NUnit " + fileNumber;
-			}
-		}
-        var runStartTime = new Date(); 
+        var runName = this.runTitleNunitAndXunit(runTitle, fileNumber, "NUnit");
+        var runStartTime = new Date();
         var totalRunDuration = 0;
 
         var rootNode = res["test-results"].at(0);
-        if(rootNode) {
+        if (rootNode) {
             if (!(runTitle && 0 !== runTitle.length)) {
-				if(rootNode.attributes().name) {
-					runName = rootNode.attributes().name;
-				}
-			}
+                if (rootNode.attributes().name) {
+                    runName = rootNode.attributes().name;
+                }
+            }
 
             var dateFromXml = new Date();
-            if(rootNode.attributes().date) {
+            if (rootNode.attributes().date) {
                 dateFromXml = rootNode.attributes().date;
             }
 
             var timeFromXml = "00:00:00";
-            if(rootNode.attributes().time) {
+            if (rootNode.attributes().time) {
                 timeFromXml = rootNode.attributes().time;
             }
-            
+
             var dateTimeFromXml = new Date(dateFromXml + "T" + timeFromXml);
             if (dateTimeFromXml < new Date()) {
                 runStartTime = dateTimeFromXml;
-            }                
+            }
         }
 
         //run environment - platform, config, hostname
@@ -399,26 +356,26 @@ export class ResultReader {
         var runUser = "";
         var hostName = "";
 
-        if(rootNode.environment) { var envNode = rootNode.environment.at(0); }
+        if (rootNode.environment) { var envNode = rootNode.environment.at(0); }
 
-        if(envNode) {
-            
-            if(envNode.attributes()["machine-name"]) {
+        if (envNode) {
+
+            if (envNode.attributes()["machine-name"]) {
                 hostName = envNode.attributes()["machine-name"];
             }
 
-            if(envNode.attributes().platform) {
+            if (envNode.attributes().platform) {
                 platform = envNode.attributes().platform;
             }
         }            
 
         //get all test cases
         var testResults = [];
-        
-        for(var t = 0; t < rootNode["test-suite"].count(); t ++) { 
+
+        for (var t = 0; t < rootNode["test-suite"].count(); t++) {
             testResults = testResults.concat(this.FindNUnitTestCaseNodes(rootNode["test-suite"].at(t), hostName, buildRequestedFor, rootNode.attributes().name));
 
-            if(rootNode["test-suite"].at(t).attributes().time) {
+            if (rootNode["test-suite"].at(t).attributes().time) {
                 totalRunDuration += parseFloat(rootNode["test-suite"].at(t).attributes().time);
             }
         }
@@ -427,7 +384,7 @@ export class ResultReader {
         completedDate.setSeconds(runStartTime.getSeconds() + totalRunDuration);
 
         //create test run data
-        var testRun: testifm.RunCreateModel = <testifm.RunCreateModel>    {
+        var testRun: testifm.RunCreateModel = <testifm.RunCreateModel>{
             name: runName,
             state: "InProgress",
             automated: true,
@@ -443,35 +400,35 @@ export class ResultReader {
         testRun2 = <ifm.TestRunWithResults>{
             testRun: testRun,
             testResults: testResults,
-        };         
+        };
 
         return testRun2;
     }
 
-    private FindNUnitTestCaseNodes(startNode, hostName : string, buildRequestedFor : string, assemblyName : string) {
-        
+    private FindNUnitTestCaseNodes(startNode, hostName: string, buildRequestedFor: string, assemblyName: string) {
+
         var foundTestResults = [];
-        
+
         var testStorage = assemblyName;
-        if(startNode.attributes().type == "Assembly") {
+        if (startNode.attributes().type == "Assembly") {
             testStorage = startNode.attributes().name;
         }
 
         //if test-case node exist, read test case information
-        if(startNode.results["test-case"]) {
-            
-            for(var i = 0; i < startNode.results["test-case"].count(); i ++) {
+        if (startNode.results["test-case"]) {
+
+            for (var i = 0; i < startNode.results["test-case"].count(); i++) {
                 var testCaseNode = startNode.results["test-case"].at(i);
                 
                 //testcase name and type
                 var testName = "";
-                if(testCaseNode.attributes().name) {
+                if (testCaseNode.attributes().name) {
                     testName = testCaseNode.attributes().name;
                 }                                                               
 
                 //testcase duration
                 var testCaseDuration = 0; //in seconds
-                if(testCaseNode.attributes().time) {
+                if (testCaseNode.attributes().time) {
                     testCaseDuration = parseFloat(testCaseNode.attributes().time);
                 }                            
 
@@ -479,17 +436,17 @@ export class ResultReader {
                 var outcome = "Passed";
                 var errorMessage = "";
                 var stackTrace = "";
-                if(testCaseNode.failure) {
+                if (testCaseNode.failure) {
                     outcome = "Failed";
-                    if(testCaseNode.failure.message && testCaseNode.failure.message.text) {
+                    if (testCaseNode.failure.message && testCaseNode.failure.message.text) {
                         errorMessage = testCaseNode.failure.message.text();
                     }
-                    if(testCaseNode.failure["stack-trace"] && testCaseNode.failure["stack-trace"].text) {
+                    if (testCaseNode.failure["stack-trace"] && testCaseNode.failure["stack-trace"].text) {
                         stackTrace = testCaseNode.failure["stack-trace"].text();
                     }
-                }      
-                
-                var testResult : testifm.TestResultCreateModel = <testifm.TestResultCreateModel> {
+                }
+
+                var testResult: testifm.TestResultCreateModel = <testifm.TestResultCreateModel>{
                     state: "Completed",
                     computerName: hostName,
                     testCasePriority: "1",
@@ -506,22 +463,22 @@ export class ResultReader {
                 };
 
                 foundTestResults.push(testResult);
-            }            
-        }   
+            }
+        }
 
-        if(startNode.results["test-suite"]) {
-            for(var j = 0; j < startNode.results["test-suite"].count(); j++) {
+        if (startNode.results["test-suite"]) {
+            for (var j = 0; j < startNode.results["test-suite"].count(); j++) {
                 foundTestResults = foundTestResults.concat(this.FindNUnitTestCaseNodes(startNode.results["test-suite"].at(j), hostName, buildRequestedFor, testStorage));
             }
-        }                      
-        
+        }
+
         return foundTestResults;
     }
 
     private parseXUnitXml(res, runContext) {
         var testRun2: ifm.TestRunWithResults;
 
-        var buildId, buildRequestedFor, platform, config, runTitle, fileNumber, runName;
+        var buildId, buildRequestedFor, platform, config, runTitle, fileNumber;
 
         if (runContext) {
             //Build ID, run user.
@@ -531,32 +488,16 @@ export class ResultReader {
             //Run environment - platform, config, host name, run title, file number.
             platform = runContext.platform;
             config = runContext.config;
-			runTitle = runContext.runTitle;
-		    fileNumber = runContext.fileNumber;
+            runTitle = runContext.runTitle;
+            fileNumber = runContext.fileNumber;
 
             //Release uri, Release environment uri
             var releaseUri = runContext.releaseUri;
             var releaseEnvironmentUri = runContext.releaseEnvironmentUri;
         }
 
-		if (runTitle && 0 !== runTitle.length) {
-			if (fileNumber == 0){
-				runName = runTitle;
-			}
-			else {
-				runName = runTitle + fileNumber;
-			}
-		}
-		else {
-			if (fileNumber == 0){
-				runName = "XUnit Test Run " + config + " " + platform;
-			}
-			else {
-				runName = "XUnit Test Run " + config + " " + platform + " " + fileNumber;
-			}
-		}
-			
-        
+        var runName = this.runTitleNunitAndXunit(runTitle, fileNumber, "XUnit Test Run", config, platform);
+
         var runStartTime = new Date();
         var totalRunDuration = 0;
         var hostName = "";
@@ -681,6 +622,54 @@ export class ResultReader {
 
         return foundTestResults;
     }
+
+    private runTitleJunit(fileName, fileNumber) {
+        var name = "JUnit";
+
+        if (fileName && 0 !== fileName.length) {
+            return (name + " " + fileName);
+        }
+        else {
+            if (fileNumber > 0) {
+                return (name + " " + fileNumber);
+            }
+        }
+
+        return name;
+    }
+
+    private runTitleNunitAndXunit(runTitle, fileNumber, formatType, config = "", platform = ""): string {
+        if (runTitle && 0 !== runTitle.length) {
+            return this.fileNumberToTitle(runTitle, parseInt(fileNumber));
+        }
+        else {
+            if (fileNumber == 0) {
+                if (config && platform && 0 !== config.length && 0 !== platform.length) {
+                    return (formatType + " " + config + " " + platform);
+                }
+                else {
+                    return formatType;
+                }
+            }
+            else {
+                if (config && platform && 0 !== config.length && 0 !== platform.length) {
+                    return (formatType + " " + config + " " + platform + " " + fileNumber);
+                }
+                else {
+                    return (formatType + " " + fileNumber);
+                }
+            }
+        }
+    }
+
+    private fileNumberToTitle(runTitle, fileNumber) {
+        if (fileNumber > 0) {
+            return (runTitle + " " + fileNumber);
+        }
+
+        return runTitle;
+    }
+
 }
 
 

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -12,61 +12,61 @@ import ifm = require('../agent/interfaces');
 import testifm = require('vso-node-api/interfaces/TestInterfaces');
 
 describe('PublisherTests', function() {
-		
-	it('results.publish : JUnit results file', function(done) {
-		this.timeout(2000);
+        
+    it('results.publish : JUnit results file', function(done) {
+        this.timeout(2000);
 
         var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "",
             config: "",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
         var reader = new trr.JUnitResultReader();
         var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-		var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-		var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
+        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
+        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
 
-		testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
-			assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-			done();
+        testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
+            assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
+            done();
         },
         function (err) {
             assert(false, 'ResultPublish Task Failed! Details : '  + err.message);
         });
     })
-    	
-	it('results.publish : NUnit results file', function (done) {
-		this.timeout(2000);
+        
+    it('results.publish : NUnit results file', function (done) {
+        this.timeout(2000);
 
-		var runContext: trp.TestRunContext = {
-			requestedFor: "userx",
-			buildId: "21",
-			platform: "",
+        var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "",
             config: "",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
-		};
-		var reader = new trr.NUnitResultReader();
-		var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
-		var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-		var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
+        };
+        var reader = new trr.NUnitResultReader();
+        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
+        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
 
-		testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
-			assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-			done();
-		},
-		function (err) {
-			assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
-		});
+        testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
+            assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
+            done();
+        },
+        function (err) {
+            assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
+        });
     })	
 
     it('results.publish : XUnit results file', function (done) {
@@ -77,9 +77,9 @@ describe('PublisherTests', function() {
             buildId: "21",
             platform: "",
             config: "",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
@@ -97,32 +97,32 @@ describe('PublisherTests', function() {
             });
     })
 
-	it('results.publish : error handling for create test run', function(done) {
-		this.timeout(2000);
+    it('results.publish : error handling for create test run', function(done) {
+        this.timeout(2000);
 
         var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "",
             config: "",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
         var reader = new trr.JUnitResultReader();
         var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-		var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-		var testRun: testifm.RunCreateModel = <any>{
-	        name: "foobar",
-	        id: -1
-	    };
+        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
+        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        var testRun: testifm.RunCreateModel = <any>{
+            name: "foobar",
+            id: -1
+        };
 
-	    // error handling/propagation from start test run 
-		testRunPublisher.startTestRun(testRun, resultsFile).then(function (createdTestRun) {
-			assert(false, 'ResultPublish Task did not fail as expected');
+        // error handling/propagation from start test run 
+        testRunPublisher.startTestRun(testRun).then(function (createdTestRun) {
+            assert(false, 'ResultPublish Task did not fail as expected');
             done();
         },
         function (err) {
@@ -131,34 +131,34 @@ describe('PublisherTests', function() {
         });
 
     })	
-    	
-	it('results.publish : error handling for end test run', function(done) {
-		this.timeout(2000);
+        
+    it('results.publish : error handling for end test run', function(done) {
+        this.timeout(2000);
 
         var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "",
             config: "",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
         var reader = new trr.JUnitResultReader();
         var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-		var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-		var testRun = {
-	        name: "foobar",
-	        id: -1,
-			resultsFile: resultsFile
-	    };
+        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
+        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        var testRun = {
+            name: "foobar",
+            id: -1,
+            resultsFile: resultsFile
+        };
 
-	    // error handling/propagation from end test run 
-		testRunPublisher.endTestRun(testRun.id, testRun.resultsFile).then(function (createdTestRun) {
-			assert(false, 'ResultPublish Task did not fail as expected');
+        // error handling/propagation from end test run 
+        testRunPublisher.endTestRun(testRun.id, testRun.resultsFile).then(function (createdTestRun) {
+            assert(false, 'ResultPublish Task did not fail as expected');
             done();
         },
         function (err) {
@@ -167,252 +167,252 @@ describe('PublisherTests', function() {
         });
     }) 
            
-	it('results.publish : error handling for reading results', function(done) {
-		this.timeout(2000);
+    it('results.publish : error handling for reading results', function(done) {
+        this.timeout(2000);
 
         var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "",
             config: "",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
         var reader = new trr.JUnitResultReader();
         var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-		var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-		
+        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
+        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        
         // error handling/propagation from parsing failures of junit/nunit files
-		resultsFile = path.resolve(__dirname, './testresults/junit_bad.xml');
-		testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
-			assert(!feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
+        resultsFile = path.resolve(__dirname, './testresults/junit_bad.xml');
+        testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
+            assert(!feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
         },
         function (err) {
             assert(err.message == "Unmatched closing tag: XYZXYZuite\nLine: 13\nColumn: 16\nChar: >",
-            	'ResultPublish Task Failed as expected! Details : '  + err.message);
+                'ResultPublish Task Failed as expected! Details : '  + err.message);
             done();
         });
-	})
-
-	it('results.publish : JUnit reader sanity check without run title', function(done) {
-		var results;
-		var testRun;
-		var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-		var reader = new trr.JUnitResultReader();
-		//var testRunWithResults = reader.readResults(resultsFile, runContext);
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			results = res.testResults;
-			
-			//Verifying the test run details
-			assert.strictEqual("JUnitXmlReporter", testRun.name);
-			//assert.equal("", testRun.startDate);
-			//assert.equal("", testRun.completeDate);
-			assert.equal("debug", testRun.buildFlavor);
-			assert.equal("mac", testRun.buildPlatform);
-			assert.equal("abc", testRun.releaseUri);
-			assert.equal("xyz", testRun.releaseEnvironmentUri);
-			assert.equal(21, testRun.build.id);
-			assert.strictEqual(true, testRun.automated);			
-			
-			
-			//Verifying Test Results
-			assert.strictEqual(3, results.length);
-			assert.strictEqual("should default path to an empty string", results[0].automatedTestName);
-			assert.strictEqual("should default consolidate to true", results[1].automatedTestName);
-			assert.strictEqual("should default useDotNotation to true", results[2].automatedTestName);
-			done();
-		},
-		function(err) {
-			assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-			done();
-		});		
-	})
-	
-	it('results.publish : JUnit reader sanity check with run title', function(done) {
-		
-		var testRun;
-		var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-			runTitle: "My Title",
-			publishRunAttachments: true,
-			fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-		var reader = new trr.JUnitResultReader();
-		//var testRunWithResults = reader.readResults(resultsFile, runContext);
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			
-			//Verifying the test run details
-			assert.strictEqual("My Title", testRun.name);			
-			done();
-		},
-		function(err) {
-			assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-			done();
-		});		
-	})
-	
-	it('results.publish : JUnit reader sanity check with run title and file number', function(done) {
-		
-		var testRun;
-		var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-			runTitle: "My Title",
-			publishRunAttachments: true,
-			fileNumber: "4",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-		var reader = new trr.JUnitResultReader();
-		//var testRunWithResults = reader.readResults(resultsFile, runContext);
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			
-			//Verifying the test run details
-			assert.strictEqual("My Title 4", testRun.name);			
-			done();
-		},
-		function(err) {
-			assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-			done();
-		});		
-	})
-	
-	it('results.publish : NUnit reader sanity check without run title', function (done) {
-		
-		var results;
-		var runContext: trp.TestRunContext = {
-			requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-		};
-		var reader = new trr.NUnitResultReader();
-		var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
-		var testRun;
-
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			results = res.testResults;
-			
-			//Verifying the test run details
-			assert.strictEqual("/Volumes/Data/xamarin/workspaces/android-csharp-test-job-c2a0f46d-7bf3-4ba8-97ce-ce8a8fdd1c4720150429-96377-8lrqzf/CreditCardValidation.Tests.dll", testRun.name);
-			//assert.equal("", testRun.startDate);
-			//assert.equal("", testRun.completeDate);
-			assert.equal("debug", testRun.buildFlavor);
-			assert.equal("mac", testRun.buildPlatform);
-			assert.equal("abc", testRun.releaseUri);
-			assert.equal("xyz", testRun.releaseEnvironmentUri);
-			assert.equal(21, testRun.build.id);
-			assert.strictEqual(true, testRun.automated);			
-			
-			
-			//Verifying Test Results
-			assert.strictEqual(4, results.length);
-			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_CorrectSize_DisplaySuccessScreen(Android)_lg_nexus_5_4_4_4", results[0].automatedTestName);
-			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_IsBlank_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[1].automatedTestName);
-			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooLong_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[2].automatedTestName);
-			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooShort_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[3].automatedTestName);
-			done();
-		},
-		function(err) {
-			assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-			done();
-		});
     })
-	
-	it('results.publish : NUnit reader sanity check with run title', function(done) {
-		
-		var testRun;
-		var runContext: trp.TestRunContext = {
+
+    it('results.publish : JUnit reader sanity check without run title', function(done) {
+        var results;
+        var testRun;
+        var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "mac",
             config: "debug",
-			runTitle: "My Title",
-			publishRunAttachments: true,
-			fileNumber: "0",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "0",
             releaseUri: "abc",
             releaseEnvironmentUri: "xyz"
         };
-		var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
-		var reader = new trr.NUnitResultReader();
-		//var testRunWithResults = reader.readResults(resultsFile, runContext);
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			
-			//Verifying the test run details
-			assert.strictEqual("My Title", testRun.name);			
-			done();
-		},
-		function(err) {
-			assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-			done();
-		});		
-	})
-	
-	it('results.publish : NUnit reader sanity check with run title and file number', function(done) {
-		
-		var testRun;
-		var runContext: trp.TestRunContext = {
+        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        var reader = new trr.JUnitResultReader();
+        //var testRunWithResults = reader.readResults(resultsFile, runContext);
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            results = res.testResults;
+            
+            //Verifying the test run details
+            assert.strictEqual("JUnitXmlReporter", testRun.name);
+            //assert.equal("", testRun.startDate);
+            //assert.equal("", testRun.completeDate);
+            assert.equal("debug", testRun.buildFlavor);
+            assert.equal("mac", testRun.buildPlatform);
+            assert.equal("abc", testRun.releaseUri);
+            assert.equal("xyz", testRun.releaseEnvironmentUri);
+            assert.equal(21, testRun.build.id);
+            assert.strictEqual(true, testRun.automated);			
+            
+            
+            //Verifying Test Results
+            assert.strictEqual(3, results.length);
+            assert.strictEqual("should default path to an empty string", results[0].automatedTestName);
+            assert.strictEqual("should default consolidate to true", results[1].automatedTestName);
+            assert.strictEqual("should default useDotNotation to true", results[2].automatedTestName);
+            done();
+        },
+        function(err) {
+            assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+            done();
+        });		
+    })
+    
+    it('results.publish : JUnit reader sanity check with run title', function(done) {
+        
+        var testRun;
+        var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "mac",
             config: "debug",
-			runTitle: "My Title",
-			publishRunAttachments: true,
-			fileNumber: "11",
+            runTitle: "My Title",
+            publishRunAttachments: true,
+            fileNumber: "0",
             releaseUri: "abc",
             releaseEnvironmentUri: "xyz"
         };
-		var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
-		var reader = new trr.NUnitResultReader();
-		//var testRunWithResults = reader.readResults(resultsFile, runContext);
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			
-			//Verifying the test run details
-			assert.strictEqual("My Title 11", testRun.name);			
-			done();
-		},
-		function(err) {
-			assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-			done();
-		});		
-	})
-	
-	
+        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        var reader = new trr.JUnitResultReader();
+        //var testRunWithResults = reader.readResults(resultsFile, runContext);
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            
+            //Verifying the test run details
+            assert.strictEqual("My Title", testRun.name);			
+            done();
+        },
+        function(err) {
+            assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+            done();
+        });		
+    })
+    
+    it('results.publish : JUnit reader sanity check with run title and file number', function(done) {
+        
+        var testRun;
+        var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+            runTitle: "My Title",
+            publishRunAttachments: true,
+            fileNumber: "4",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        var reader = new trr.JUnitResultReader();
+        //var testRunWithResults = reader.readResults(resultsFile, runContext);
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            
+            //Verifying the test run details
+            assert.strictEqual("My Title 4", testRun.name);			
+            done();
+        },
+        function(err) {
+            assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+            done();
+        });		
+    })
+    
+    it('results.publish : NUnit reader sanity check without run title', function (done) {
+        
+        var results;
+        var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+        var reader = new trr.NUnitResultReader();
+        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+        var testRun;
+
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            results = res.testResults;
+            
+            //Verifying the test run details
+            assert.strictEqual("/Volumes/Data/xamarin/workspaces/android-csharp-test-job-c2a0f46d-7bf3-4ba8-97ce-ce8a8fdd1c4720150429-96377-8lrqzf/CreditCardValidation.Tests.dll", testRun.name);
+            //assert.equal("", testRun.startDate);
+            //assert.equal("", testRun.completeDate);
+            assert.equal("debug", testRun.buildFlavor);
+            assert.equal("mac", testRun.buildPlatform);
+            assert.equal("abc", testRun.releaseUri);
+            assert.equal("xyz", testRun.releaseEnvironmentUri);
+            assert.equal(21, testRun.build.id);
+            assert.strictEqual(true, testRun.automated);			
+            
+            
+            //Verifying Test Results
+            assert.strictEqual(4, results.length);
+            assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_CorrectSize_DisplaySuccessScreen(Android)_lg_nexus_5_4_4_4", results[0].automatedTestName);
+            assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_IsBlank_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[1].automatedTestName);
+            assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooLong_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[2].automatedTestName);
+            assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooShort_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[3].automatedTestName);
+            done();
+        },
+        function(err) {
+            assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+            done();
+        });
+    })
+    
+    it('results.publish : NUnit reader sanity check with run title', function(done) {
+        
+        var testRun;
+        var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+            runTitle: "My Title",
+            publishRunAttachments: true,
+            fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+        var reader = new trr.NUnitResultReader();
+        //var testRunWithResults = reader.readResults(resultsFile, runContext);
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            
+            //Verifying the test run details
+            assert.strictEqual("My Title", testRun.name);			
+            done();
+        },
+        function(err) {
+            assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+            done();
+        });		
+    })
+    
+    it('results.publish : NUnit reader sanity check with run title and file number', function(done) {
+        
+        var testRun;
+        var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+            runTitle: "My Title",
+            publishRunAttachments: true,
+            fileNumber: "11",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+        var reader = new trr.NUnitResultReader();
+        //var testRunWithResults = reader.readResults(resultsFile, runContext);
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            
+            //Verifying the test run details
+            assert.strictEqual("My Title 11", testRun.name);			
+            done();
+        },
+        function(err) {
+            assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+            done();
+        });		
+    })
+    
+    
     it('results.publish : XUnit reader sanity check without run title', function (done) {
         var results;
         var runContext: trp.TestRunContext = {
@@ -420,103 +420,103 @@ describe('PublisherTests', function() {
             buildId: "21",
             platform: "mac",
             config: "debug",
-			runTitle: "",
-			publishRunAttachments: true,
-			fileNumber: "0",
+            runTitle: "",
+            publishRunAttachments: true,
+            fileNumber: "0",
             releaseUri: "abc",
             releaseEnvironmentUri: "xyz"
         };
         var reader = new trr.XUnitResultReader();
         var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
         var testRun;
-		
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			results = res.testResults;
-			
-			//Verifying the test run details
-			assert.strictEqual("XUnit Test Run debug mac", testRun.name);
-			//assert.equal("", testRun.startDate);
-			//assert.equal("", testRun.completeDate);
-			assert.equal("debug", testRun.buildFlavor);
-			assert.equal("mac", testRun.buildPlatform);
-			assert.equal("abc", testRun.releaseUri);
-			assert.equal("xyz", testRun.releaseEnvironmentUri);
-			assert.equal(21, testRun.build.id);
-			assert.strictEqual(true, testRun.automated);			
-			
-			
-			//Verifying Test Results
-			assert.strictEqual(4, results.length);
-			assert.strictEqual("FailingTest", results[0].automatedTestName);
-			assert.strictEqual("PassingTest", results[1].automatedTestName);
-			assert.strictEqual("tset2", results[2].automatedTestName);
-			assert.strictEqual("test1", results[3].automatedTestName);
-			done();
-		},
-		function(err) {
-			assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-			done();
-		}); 
+        
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            results = res.testResults;
+            
+            //Verifying the test run details
+            assert.strictEqual("XUnit Test Run debug mac", testRun.name);
+            //assert.equal("", testRun.startDate);
+            //assert.equal("", testRun.completeDate);
+            assert.equal("debug", testRun.buildFlavor);
+            assert.equal("mac", testRun.buildPlatform);
+            assert.equal("abc", testRun.releaseUri);
+            assert.equal("xyz", testRun.releaseEnvironmentUri);
+            assert.equal(21, testRun.build.id);
+            assert.strictEqual(true, testRun.automated);			
+            
+            
+            //Verifying Test Results
+            assert.strictEqual(4, results.length);
+            assert.strictEqual("FailingTest", results[0].automatedTestName);
+            assert.strictEqual("PassingTest", results[1].automatedTestName);
+            assert.strictEqual("tset2", results[2].automatedTestName);
+            assert.strictEqual("test1", results[3].automatedTestName);
+            done();
+        },
+        function(err) {
+            assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+            done();
+        }); 
     })
-	
-	it('results.publish : XUnit reader sanity check with run title', function(done) {
-		
-		var testRun;
-		var runContext: trp.TestRunContext = {
+    
+    it('results.publish : XUnit reader sanity check with run title', function(done) {
+        
+        var testRun;
+        var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "mac",
             config: "debug",
-			runTitle: "My Title",
-			publishRunAttachments: true,
-			fileNumber: "0",
+            runTitle: "My Title",
+            publishRunAttachments: true,
+            fileNumber: "0",
             releaseUri: "abc",
             releaseEnvironmentUri: "xyz"
         };
-		var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
-		var reader = new trr.XUnitResultReader();
-		//var testRunWithResults = reader.readResults(resultsFile, runContext);
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			
-			//Verifying the test run details
-			assert.strictEqual("My Title", testRun.name);			
-			done();
-		},
-		function(err) {
-			assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-			done();
-		});		
-	})
-	
-	it('results.publish : XUnit reader sanity check with run title and file number', function(done) {
-		
-		var testRun;
-		var runContext: trp.TestRunContext = {
+        var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
+        var reader = new trr.XUnitResultReader();
+        //var testRunWithResults = reader.readResults(resultsFile, runContext);
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            
+            //Verifying the test run details
+            assert.strictEqual("My Title", testRun.name);			
+            done();
+        },
+        function(err) {
+            assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+            done();
+        });		
+    })
+    
+    it('results.publish : XUnit reader sanity check with run title and file number', function(done) {
+        
+        var testRun;
+        var runContext: trp.TestRunContext = {
             requestedFor: "userx",
             buildId: "21",
             platform: "",
             config: "",
-			runTitle: "My Title",
-			publishRunAttachments: true,
-			fileNumber: "9",
+            runTitle: "My Title",
+            publishRunAttachments: true,
+            fileNumber: "9",
             releaseUri: "abc",
             releaseEnvironmentUri: "xyz"
         };
-		var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
-		var reader = new trr.XUnitResultReader();
-		//var testRunWithResults = reader.readResults(resultsFile, runContext);
-		reader.readResults(resultsFile, runContext).then(function (res) {
-			testRun = res.testRun;
-			
-			//Verifying the test run details
-			assert.strictEqual("My Title 9", testRun.name);			
-			done();
-		},
-		function(err) {
-			assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-			done();
-		});		
-	})
+        var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
+        var reader = new trr.XUnitResultReader();
+        //var testRunWithResults = reader.readResults(resultsFile, runContext);
+        reader.readResults(resultsFile, runContext).then(function (res) {
+            testRun = res.testRun;
+            
+            //Verifying the test run details
+            assert.strictEqual("My Title 9", testRun.name);			
+            done();
+        },
+        function(err) {
+            assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+            done();
+        });		
+    })
 });	

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -12,55 +12,51 @@ import ifm = require('../agent/interfaces');
 import testifm = require('vso-node-api/interfaces/TestInterfaces');
 
 describe('PublisherTests', function() {
-        
+    
+    var runContext: trp.TestRunContext = {
+        requestedFor: "userx",
+        buildId: "21",
+        platform: "mac",
+        config: "debug",
+        runTitle: "My Title",
+        publishRunAttachments: true,
+        fileNumber: "3",
+        releaseUri: "abc",
+        releaseEnvironmentUri: "xyz"
+    };  
+
+    var readerJUnit = new trr.JUnitResultReader();    
+    var readerNUnit = new trr.NUnitResultReader();
+    var readerXUnit = new trr.XUnitResultReader();
+
+    var resultsFileJUnit = path.resolve(__dirname, './testresults/junitresults1.xml');
+    var resultsFileNUnit = path.resolve(__dirname, './testresults/nunitresults.xml');
+    var resultsFileXUnit = path.resolve(__dirname, './testresults/xunitresults.xml');
+
+    var feedbackChannel;
+    var testRunPublisher;
+
     it('results.publish : JUnit results file', function(done) {
         this.timeout(2000);
+        
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
 
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "",
-            config: "",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "",
-            releaseUri: "",
-            releaseEnvironmentUri: ""
-        };
-        var reader = new trr.JUnitResultReader();
-        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-
-        testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
+        testRunPublisher.publishTestRun(resultsFileJUnit).then(function (createdTestRun) {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
             done();
         },
         function (err) {
             assert(false, 'ResultPublish Task Failed! Details : '  + err.message);
         });
-    })
+    })    
         
     it('results.publish : NUnit results file', function (done) {
         this.timeout(2000);
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerNUnit);
 
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "",
-            config: "",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "",
-            releaseUri: "",
-            releaseEnvironmentUri: ""
-        };
-        var reader = new trr.NUnitResultReader();
-        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
-        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-
-        testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
+        testRunPublisher.publishTestRun(resultsFileNUnit).then(function (createdTestRun) {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
             done();
         },
@@ -71,24 +67,11 @@ describe('PublisherTests', function() {
 
     it('results.publish : XUnit results file', function (done) {
         this.timeout(2000);
+        
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerXUnit);
 
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "",
-            config: "",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "",
-            releaseUri: "",
-            releaseEnvironmentUri: ""
-        };
-        var reader = new trr.XUnitResultReader();
-        var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
-        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-
-        testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
+        testRunPublisher.publishTestRun(resultsFileXUnit).then(function (createdTestRun) {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
             done();
         },
@@ -100,21 +83,9 @@ describe('PublisherTests', function() {
     it('results.publish : error handling for create test run', function(done) {
         this.timeout(2000);
 
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "",
-            config: "",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "",
-            releaseUri: "",
-            releaseEnvironmentUri: ""
-        };
-        var reader = new trr.JUnitResultReader();
-        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
+
         var testRun: testifm.RunCreateModel = <any>{
             name: "foobar",
             id: -1
@@ -135,25 +106,12 @@ describe('PublisherTests', function() {
     it('results.publish : error handling for end test run', function(done) {
         this.timeout(2000);
 
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "",
-            config: "",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "",
-            releaseUri: "",
-            releaseEnvironmentUri: ""
-        };
-        var reader = new trr.JUnitResultReader();
-        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
         var testRun = {
             name: "foobar",
             id: -1,
-            resultsFile: resultsFile
+            resultsFile: resultsFileJUnit
         };
 
         // error handling/propagation from end test run 
@@ -170,24 +128,11 @@ describe('PublisherTests', function() {
     it('results.publish : error handling for reading results', function(done) {
         this.timeout(2000);
 
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "",
-            config: "",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "",
-            releaseUri: "",
-            releaseEnvironmentUri: ""
-        };
-        var reader = new trr.JUnitResultReader();
-        var feedbackChannel: fm.TestFeedbackChannel = new fm.TestFeedbackChannel();
-        var testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, reader);
-        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
         
         // error handling/propagation from parsing failures of junit/nunit files
-        resultsFile = path.resolve(__dirname, './testresults/junit_bad.xml');
+        var resultsFile = path.resolve(__dirname, './testresults/junit_bad.xml');
         testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
             assert(!feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
         },
@@ -198,31 +143,20 @@ describe('PublisherTests', function() {
         });
     })
 
-    it('results.publish : JUnit reader sanity check without run title', function(done) {
+    it('results.publish : JUnit reader sanity check without run title', function (done) {
+
         var results;
-        var testRun;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-        var reader = new trr.JUnitResultReader();
-        //var testRunWithResults = reader.readResults(resultsFile, runContext);
-        reader.readResults(resultsFile, runContext).then(function (res) {
+        var testRun;  
+        
+        runContext.runTitle = "";
+        runContext.fileNumber = "0";
+
+        readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
             testRun = res.testRun;
             results = res.testResults;
             
             //Verifying the test run details
             assert.strictEqual("JUnitXmlReporter", testRun.name);
-            //assert.equal("", testRun.startDate);
-            //assert.equal("", testRun.completeDate);
             assert.equal("debug", testRun.buildFlavor);
             assert.equal("mac", testRun.buildPlatform);
             assert.equal("abc", testRun.releaseUri);
@@ -247,21 +181,11 @@ describe('PublisherTests', function() {
     it('results.publish : JUnit reader sanity check with run title', function(done) {
         
         var testRun;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "My Title",
-            publishRunAttachments: true,
-            fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-        var reader = new trr.JUnitResultReader();
-        //var testRunWithResults = reader.readResults(resultsFile, runContext);
-        reader.readResults(resultsFile, runContext).then(function (res) {
+
+        runContext.runTitle = "My Title";
+        runContext.fileNumber = "0";        
+
+        readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
@@ -276,26 +200,15 @@ describe('PublisherTests', function() {
     
     it('results.publish : JUnit reader sanity check with run title and file number', function(done) {
         
-        var testRun;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "My Title",
-            publishRunAttachments: true,
-            fileNumber: "4",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
-        var reader = new trr.JUnitResultReader();
-        //var testRunWithResults = reader.readResults(resultsFile, runContext);
-        reader.readResults(resultsFile, runContext).then(function (res) {
+        var testRun;        
+        
+        runContext.fileNumber = "3";
+
+        readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title 4", testRun.name);			
+            assert.strictEqual("My Title 3", testRun.name);			
             done();
         },
         function(err) {
@@ -306,30 +219,18 @@ describe('PublisherTests', function() {
     
     it('results.publish : NUnit reader sanity check without run title', function (done) {
         
-        var results;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var reader = new trr.NUnitResultReader();
-        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+        var results;        
         var testRun;
 
-        reader.readResults(resultsFile, runContext).then(function (res) {
+        runContext.runTitle = "";
+        runContext.fileNumber = "0";
+
+        readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
             testRun = res.testRun;
             results = res.testResults;
             
             //Verifying the test run details
             assert.strictEqual("/Volumes/Data/xamarin/workspaces/android-csharp-test-job-c2a0f46d-7bf3-4ba8-97ce-ce8a8fdd1c4720150429-96377-8lrqzf/CreditCardValidation.Tests.dll", testRun.name);
-            //assert.equal("", testRun.startDate);
-            //assert.equal("", testRun.completeDate);
             assert.equal("debug", testRun.buildFlavor);
             assert.equal("mac", testRun.buildPlatform);
             assert.equal("abc", testRun.releaseUri);
@@ -355,21 +256,11 @@ describe('PublisherTests', function() {
     it('results.publish : NUnit reader sanity check with run title', function(done) {
         
         var testRun;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "My Title",
-            publishRunAttachments: true,
-            fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
-        var reader = new trr.NUnitResultReader();
-        //var testRunWithResults = reader.readResults(resultsFile, runContext);
-        reader.readResults(resultsFile, runContext).then(function (res) {
+
+        runContext.runTitle = "My Title";
+        runContext.fileNumber = "0";      
+        
+        readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
@@ -385,25 +276,13 @@ describe('PublisherTests', function() {
     it('results.publish : NUnit reader sanity check with run title and file number', function(done) {
         
         var testRun;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "My Title",
-            publishRunAttachments: true,
-            fileNumber: "11",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
-        var reader = new trr.NUnitResultReader();
-        //var testRunWithResults = reader.readResults(resultsFile, runContext);
-        reader.readResults(resultsFile, runContext).then(function (res) {
+        runContext.fileNumber = "3";
+          
+        readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title 11", testRun.name);			
+            assert.strictEqual("My Title 3", testRun.name);			
             done();
         },
         function(err) {
@@ -414,30 +293,19 @@ describe('PublisherTests', function() {
     
     
     it('results.publish : XUnit reader sanity check without run title', function (done) {
+
         var results;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "",
-            publishRunAttachments: true,
-            fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var reader = new trr.XUnitResultReader();
-        var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
         var testRun;
-        
-        reader.readResults(resultsFile, runContext).then(function (res) {
+
+        runContext.runTitle = "";
+        runContext.fileNumber = "0"; 
+               
+        readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
             testRun = res.testRun;
             results = res.testResults;
             
             //Verifying the test run details
             assert.strictEqual("XUnit Test Run debug mac", testRun.name);
-            //assert.equal("", testRun.startDate);
-            //assert.equal("", testRun.completeDate);
             assert.equal("debug", testRun.buildFlavor);
             assert.equal("mac", testRun.buildPlatform);
             assert.equal("abc", testRun.releaseUri);
@@ -463,21 +331,11 @@ describe('PublisherTests', function() {
     it('results.publish : XUnit reader sanity check with run title', function(done) {
         
         var testRun;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "mac",
-            config: "debug",
-            runTitle: "My Title",
-            publishRunAttachments: true,
-            fileNumber: "0",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
-        var reader = new trr.XUnitResultReader();
-        //var testRunWithResults = reader.readResults(resultsFile, runContext);
-        reader.readResults(resultsFile, runContext).then(function (res) {
+
+        runContext.runTitle = "My Title";
+        runContext.fileNumber = "0";
+        
+        readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
@@ -492,31 +350,22 @@ describe('PublisherTests', function() {
     
     it('results.publish : XUnit reader sanity check with run title and file number', function(done) {
         
-        var testRun;
-        var runContext: trp.TestRunContext = {
-            requestedFor: "userx",
-            buildId: "21",
-            platform: "",
-            config: "",
-            runTitle: "My Title",
-            publishRunAttachments: true,
-            fileNumber: "9",
-            releaseUri: "abc",
-            releaseEnvironmentUri: "xyz"
-        };
-        var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
-        var reader = new trr.XUnitResultReader();
-        //var testRunWithResults = reader.readResults(resultsFile, runContext);
-        reader.readResults(resultsFile, runContext).then(function (res) {
+        var testRun;        
+        
+        runContext.fileNumber = "3";
+        readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title 9", testRun.name);			
+            assert.strictEqual("My Title 3", testRun.name);
             done();
         },
-        function(err) {
-            assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-            done();
-        });		
+            function (err) {
+                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+                done(err);
+            }).fail(function (err) {
+                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+                done(err);
+            });		
     })
 });	

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -8,6 +8,7 @@ import path = require('path');
 import fm = require('./lib/feedback');
 import trp = require('../agent/testrunpublisher');
 import trr = require('../agent/testresultreader');
+import ifm = require('../agent/interfaces');
 import testifm = require('vso-node-api/interfaces/TestInterfaces');
 
 describe('PublisherTests', function() {
@@ -195,5 +196,327 @@ describe('PublisherTests', function() {
             	'ResultPublish Task Failed as expected! Details : '  + err.message);
             done();
         });
-	})		
+	})
+
+	it('results.publish : JUnit reader sanity check without run title', function(done) {
+		var results;
+		var testRun;
+		var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+		var reader = new trr.JUnitResultReader();
+		//var testRunWithResults = reader.readResults(resultsFile, runContext);
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			results = res.testResults;
+			
+			//Verifying the test run details
+			assert.strictEqual("JUnitXmlReporter", testRun.name);
+			//assert.equal("", testRun.startDate);
+			//assert.equal("", testRun.completeDate);
+			assert.equal("debug", testRun.buildFlavor);
+			assert.equal("mac", testRun.buildPlatform);
+			assert.equal("abc", testRun.releaseUri);
+			assert.equal("xyz", testRun.releaseEnvironmentUri);
+			assert.equal(21, testRun.build.id);
+			assert.strictEqual(true, testRun.automated);			
+			
+			
+			//Verifying Test Results
+			assert.strictEqual(3, results.length);
+			assert.strictEqual("should default path to an empty string", results[0].automatedTestName);
+			assert.strictEqual("should default consolidate to true", results[1].automatedTestName);
+			assert.strictEqual("should default useDotNotation to true", results[2].automatedTestName);
+			done();
+		},
+		function(err) {
+			assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+			done();
+		});		
+	})
+	
+	it('results.publish : JUnit reader sanity check with run title', function(done) {
+		
+		var testRun;
+		var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "My Title",
+			publishRunAttachments: true,
+			fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+		var reader = new trr.JUnitResultReader();
+		//var testRunWithResults = reader.readResults(resultsFile, runContext);
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			
+			//Verifying the test run details
+			assert.strictEqual("My Title", testRun.name);			
+			done();
+		},
+		function(err) {
+			assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+			done();
+		});		
+	})
+	
+	it('results.publish : JUnit reader sanity check with run title and file number', function(done) {
+		
+		var testRun;
+		var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "My Title",
+			publishRunAttachments: true,
+			fileNumber: "4",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
+		var reader = new trr.JUnitResultReader();
+		//var testRunWithResults = reader.readResults(resultsFile, runContext);
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			
+			//Verifying the test run details
+			assert.strictEqual("My Title 4", testRun.name);			
+			done();
+		},
+		function(err) {
+			assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+			done();
+		});		
+	})
+	
+	it('results.publish : NUnit reader sanity check without run title', function (done) {
+		
+		var results;
+		var runContext: trp.TestRunContext = {
+			requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+		};
+		var reader = new trr.NUnitResultReader();
+		var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+		var testRun;
+
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			results = res.testResults;
+			
+			//Verifying the test run details
+			assert.strictEqual("/Volumes/Data/xamarin/workspaces/android-csharp-test-job-c2a0f46d-7bf3-4ba8-97ce-ce8a8fdd1c4720150429-96377-8lrqzf/CreditCardValidation.Tests.dll", testRun.name);
+			//assert.equal("", testRun.startDate);
+			//assert.equal("", testRun.completeDate);
+			assert.equal("debug", testRun.buildFlavor);
+			assert.equal("mac", testRun.buildPlatform);
+			assert.equal("abc", testRun.releaseUri);
+			assert.equal("xyz", testRun.releaseEnvironmentUri);
+			assert.equal(21, testRun.build.id);
+			assert.strictEqual(true, testRun.automated);			
+			
+			
+			//Verifying Test Results
+			assert.strictEqual(4, results.length);
+			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_CorrectSize_DisplaySuccessScreen(Android)_lg_nexus_5_4_4_4", results[0].automatedTestName);
+			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_IsBlank_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[1].automatedTestName);
+			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooLong_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[2].automatedTestName);
+			assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooShort_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[3].automatedTestName);
+			done();
+		},
+		function(err) {
+			assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+			done();
+		});
+    })
+	
+	it('results.publish : NUnit reader sanity check with run title', function(done) {
+		
+		var testRun;
+		var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "My Title",
+			publishRunAttachments: true,
+			fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+		var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+		var reader = new trr.NUnitResultReader();
+		//var testRunWithResults = reader.readResults(resultsFile, runContext);
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			
+			//Verifying the test run details
+			assert.strictEqual("My Title", testRun.name);			
+			done();
+		},
+		function(err) {
+			assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+			done();
+		});		
+	})
+	
+	it('results.publish : NUnit reader sanity check with run title and file number', function(done) {
+		
+		var testRun;
+		var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "My Title",
+			publishRunAttachments: true,
+			fileNumber: "11",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+		var resultsFile = path.resolve(__dirname, './testresults/nunitresults.xml');
+		var reader = new trr.NUnitResultReader();
+		//var testRunWithResults = reader.readResults(resultsFile, runContext);
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			
+			//Verifying the test run details
+			assert.strictEqual("My Title 11", testRun.name);			
+			done();
+		},
+		function(err) {
+			assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+			done();
+		});		
+	})
+	
+	
+    it('results.publish : XUnit reader sanity check without run title', function (done) {
+        var results;
+        var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+        var reader = new trr.XUnitResultReader();
+        var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
+        var testRun;
+		
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			results = res.testResults;
+			
+			//Verifying the test run details
+			assert.strictEqual("XUnit Test Run debug mac", testRun.name);
+			//assert.equal("", testRun.startDate);
+			//assert.equal("", testRun.completeDate);
+			assert.equal("debug", testRun.buildFlavor);
+			assert.equal("mac", testRun.buildPlatform);
+			assert.equal("abc", testRun.releaseUri);
+			assert.equal("xyz", testRun.releaseEnvironmentUri);
+			assert.equal(21, testRun.build.id);
+			assert.strictEqual(true, testRun.automated);			
+			
+			
+			//Verifying Test Results
+			assert.strictEqual(4, results.length);
+			assert.strictEqual("FailingTest", results[0].automatedTestName);
+			assert.strictEqual("PassingTest", results[1].automatedTestName);
+			assert.strictEqual("tset2", results[2].automatedTestName);
+			assert.strictEqual("test1", results[3].automatedTestName);
+			done();
+		},
+		function(err) {
+			assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+			done();
+		}); 
+    })
+	
+	it('results.publish : XUnit reader sanity check with run title', function(done) {
+		
+		var testRun;
+		var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "mac",
+            config: "debug",
+			runTitle: "My Title",
+			publishRunAttachments: true,
+			fileNumber: "0",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+		var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
+		var reader = new trr.XUnitResultReader();
+		//var testRunWithResults = reader.readResults(resultsFile, runContext);
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			
+			//Verifying the test run details
+			assert.strictEqual("My Title", testRun.name);			
+			done();
+		},
+		function(err) {
+			assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+			done();
+		});		
+	})
+	
+	it('results.publish : XUnit reader sanity check with run title and file number', function(done) {
+		
+		var testRun;
+		var runContext: trp.TestRunContext = {
+            requestedFor: "userx",
+            buildId: "21",
+            platform: "",
+            config: "",
+			runTitle: "My Title",
+			publishRunAttachments: true,
+			fileNumber: "9",
+            releaseUri: "abc",
+            releaseEnvironmentUri: "xyz"
+        };
+		var resultsFile = path.resolve(__dirname, './testresults/xunitresults.xml');
+		var reader = new trr.XUnitResultReader();
+		//var testRunWithResults = reader.readResults(resultsFile, runContext);
+		reader.readResults(resultsFile, runContext).then(function (res) {
+			testRun = res.testRun;
+			
+			//Verifying the test run details
+			assert.strictEqual("My Title 9", testRun.name);			
+			done();
+		},
+		function(err) {
+			assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+			done();
+		});		
+	})
 });	

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -20,6 +20,9 @@ describe('PublisherTests', function() {
             buildId: "21",
             platform: "",
             config: "",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
@@ -45,6 +48,9 @@ describe('PublisherTests', function() {
 			buildId: "21",
 			platform: "",
             config: "",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
 		};
@@ -70,6 +76,9 @@ describe('PublisherTests', function() {
             buildId: "21",
             platform: "",
             config: "",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
@@ -95,6 +104,9 @@ describe('PublisherTests', function() {
             buildId: "21",
             platform: "",
             config: "",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
@@ -127,6 +139,9 @@ describe('PublisherTests', function() {
             buildId: "21",
             platform: "",
             config: "",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };
@@ -136,11 +151,12 @@ describe('PublisherTests', function() {
 		var resultsFile = path.resolve(__dirname, './testresults/junitresults1.xml');
 		var testRun = {
 	        name: "foobar",
-	        id: -1
+	        id: -1,
+			resultsFile: resultsFile
 	    };
 
 	    // error handling/propagation from end test run 
-		testRunPublisher.endTestRun(testRun.id).then(function (createdTestRun) {
+		testRunPublisher.endTestRun(testRun.id, testRun.resultsFile).then(function (createdTestRun) {
 			assert(false, 'ResultPublish Task did not fail as expected');
             done();
         },
@@ -158,6 +174,9 @@ describe('PublisherTests', function() {
             buildId: "21",
             platform: "",
             config: "",
+			runTitle: "",
+			publishRunAttachments: true,
+			fileNumber: "",
             releaseUri: "",
             releaseEnvironmentUri: ""
         };


### PR DESCRIPTION
Description: The PublishTestResults Task's xplat implementation is currently different from windows implementation. Users choice of Run Title and option to not publish result files do not exist in the current xplat implementation.

Solution: Changes have been made for Junit, xunit and nunit to honor users choice of run ttitle and user can now opt out of publishing test attachments. Link to vso-agent-tasks: https://github.com/Microsoft/vso-agent-tasks/pull/954. Link to vso-task-lib changes:  https://github.com/Microsoft/vso-task-lib/pull/19

Testing: Manual testing for now. Appropriate unit tests will be added if required.