### PR TITLE
Junit test results publish with multiple failure nodes

### DIFF
--- a/src/agent/commands/results.publish.ts
+++ b/src/agent/commands/results.publish.ts
@@ -29,19 +29,19 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
 
         var teamProject = this.executionContext.variables["system.teamProject"];
         var resultFilePath: string = this.command.message;
-        
+
         var resultType: string = this.command.properties['type'];
-        if(resultType) { 
-            resultType = resultType.toLowerCase(); 
+        if (resultType) {
+            resultType = resultType.toLowerCase();
         }
 
         var platform: string = this.command.properties['platform'];
-        var config : string = this.command.properties['config'];
-        var runTitle : string = this.command.properties['runTitle'];
-        var fileNumber : string = this.command.properties['fileNumber'];
-        var publishRunAttachments : boolean = (this.command.properties['publishRunAttachments'] === "true");
+        var config: string = this.command.properties['config'];
+        var runTitle: string = this.command.properties['runTitle'];
+        var fileNumber: string = this.command.properties['fileNumber'];
+        var publishRunAttachments: boolean = (this.command.properties['publishRunAttachments'] === "true");
         var command = this.command;
-        
+
         var testRunContext: trp.TestRunContext = {
             requestedFor: this.executionContext.variables["build.requestedFor"],
             buildId: this.executionContext.variables["build.buildId"],
@@ -73,15 +73,15 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
             testRunPublisher.publishTestRun(resultFilePath).then(function (createdTestRun) {
                 defer.resolve(null);
             })
-            .fail((err) => {
-                this.command.warning("Failed to publish test results: " + err.message);
-                defer.resolve(null);
-            });
+                .fail((err) => {
+                    this.command.warning("Failed to publish test results: " + err.message);
+                    defer.resolve(null);
+                });
         }
         else {
             defer.resolve(null);
         }
 
         return defer.promise;
-    }   
+    }
 }

--- a/src/agent/commands/results.publish.ts
+++ b/src/agent/commands/results.publish.ts
@@ -56,13 +56,13 @@ export class ResultsPublishCommand implements cm.IAsyncCommand {
 
         var reader;
         if (resultType == "junit") {
-            reader = new trr.JUnitResultReader();
+            reader = new trr.JUnitResultReader(this.command);
         }
         else if (resultType == "nunit") {
-            reader = new trr.NUnitResultReader();
+            reader = new trr.NUnitResultReader(this.command);
         }
         else if (resultType == "xunit") {
-            reader = new trr.XUnitResultReader();
+            reader = new trr.XUnitResultReader(this.command);
         }
         else if (resultType == "vstest") {
             this.command.warning("Test results of format '" + resultType + "'' are not supported on this build agent");

--- a/src/agent/testresultreader.ts
+++ b/src/agent/testresultreader.ts
@@ -288,7 +288,9 @@ export class ResultReader {
                 var testNode;
 
                 if (testCaseNode.failure.count() > 1) {
-                    this.command.warning("Multiple failures in the test case: " + testName + ". Picking the first for publishing!");
+                    if (this.command) {
+                        this.command.info("Multiple failures in the test case: " + testName + ". Picking the first for publishing!");
+                    }
                     testNode = testCaseNode.failure.at(0);
                 }
                 else {
@@ -308,7 +310,9 @@ export class ResultReader {
                 var testNode;
 
                 if (testCaseNode.error.count() > 1) {
-                    this.command.warning("Multiple failures in the test case: " + testName + ". Picking the first for publishing!");
+                    if (this.command) {
+                        this.command.info("Multiple errors in the test case: " + testName + ". Picking the first for publishing!");
+                    }
                     testNode = testCaseNode.error.at(0);
                 }
                 else {

--- a/src/agent/testresultreader.ts
+++ b/src/agent/testresultreader.ts
@@ -10,17 +10,17 @@ var xmlreader = require('xmlreader');
 var Q = require('q');
 
 export class JUnitResultReader implements trp.IResultReader {
-    
-	public command: cm.ITaskCommand;
-	
-	constructor(command: cm.ITaskCommand) {
+
+    public command: cm.ITaskCommand;
+
+    constructor(command: cm.ITaskCommand) {
         this.command = command;
     }
-	
-    public readResults(file: string, runContext: trp.TestRunContext) : Q.Promise<ifm.TestRunWithResults> {
+
+    public readResults(file: string, runContext: trp.TestRunContext): Q.Promise<ifm.TestRunWithResults> {
         return new ResultReader("junit", this.command).readResults(file, runContext);
     }
-          
+
 }
 
 //-----------------------------------------------------
@@ -28,34 +28,34 @@ export class JUnitResultReader implements trp.IResultReader {
 // - file: string () - location of the NUnit results file 
 //-----------------------------------------------------
 export class NUnitResultReader implements trp.IResultReader {
-    
-	public command: cm.ITaskCommand;
-	
-	constructor(command: cm.ITaskCommand) {
+
+    public command: cm.ITaskCommand;
+
+    constructor(command: cm.ITaskCommand) {
         this.command = command;
     }
-	
-    public readResults(file: string, runContext: trp.TestRunContext) : Q.Promise<ifm.TestRunWithResults> {
-        return  new ResultReader("nunit", this.command).readResults(file, runContext);
-    }    
+
+    public readResults(file: string, runContext: trp.TestRunContext): Q.Promise<ifm.TestRunWithResults> {
+        return new ResultReader("nunit", this.command).readResults(file, runContext);
+    }
 
 }
 
 export class XUnitResultReader implements trp.IResultReader {
-	
-	public command: cm.ITaskCommand;
-	
-	constructor(command: cm.ITaskCommand) {
+
+    public command: cm.ITaskCommand;
+
+    constructor(command: cm.ITaskCommand) {
         this.command = command;
     }
-	
+
     public readResults(file: string, runContext: trp.TestRunContext): Q.Promise<ifm.TestRunWithResults> {
         return new ResultReader("xunit", this.command).readResults(file, runContext);
     }
 
 }
 
-export class TestSuiteSummary {  
+export class TestSuiteSummary {
     name: string;
     host: string;
     timeStamp: Date;
@@ -69,7 +69,7 @@ export class TestSuiteSummary {
         this.duration = 0;
         this.results = [];
     }
-    
+
     addResults(res) {
         this.results = this.results.concat(res);
     }
@@ -79,11 +79,11 @@ export class ResultReader {
 
     constructor(readerType: string, command: cm.ITaskCommand) {
         this.type = readerType;
-		this.command = command;
+        this.command = command;
     }
 
     private type: string;
-	public command: cm.ITaskCommand;
+    public command: cm.ITaskCommand;
 
     public readResults(file: string, runContext: trp.TestRunContext): Q.Promise<ifm.TestRunWithResults> {
         var defer = Q.defer();
@@ -171,8 +171,8 @@ export class ResultReader {
         if (testSuitesNode) {
             if (testSuitesNode.testsuite) {
                 var numTestSuites = testSuitesNode.testsuite.count();
-				
-				for (var n = 0; n < numTestSuites; n++) {
+
+                for (var n = 0; n < numTestSuites; n++) {
                     var testSuiteSummary = this.readTestSuiteJUnitXml(testSuitesNode.testsuite.at(n), buildRequestedFor, runTitle, fileNumber, fileName);
                     runSummary.duration += testSuiteSummary.duration;
                     runSummary.addResults(testSuiteSummary.results);
@@ -285,36 +285,36 @@ export class ResultReader {
             var stackTrace = "";
             if (testCaseNode.failure) {
                 outcome = "Failed";
-				var testNode;
-				
-				if(testCaseNode.failure.count() > 1){
-					this.command.warning("Multiple failures in the test case: " + testName + ". Picking the first for publishing!");
-					testNode = testCaseNode.failure.at(0);
-				}
-				else{
-					testNode = testCaseNode.failure;
-				}
-				
+                var testNode;
+
+                if (testCaseNode.failure.count() > 1) {
+                    this.command.warning("Multiple failures in the test case: " + testName + ". Picking the first for publishing!");
+                    testNode = testCaseNode.failure.at(0);
+                }
+                else {
+                    testNode = testCaseNode.failure;
+                }
+
                 if (testNode.text) {
                     stackTrace = testNode.text();
                 }
-				
+
                 if (testNode.attributes().message) {
                     errorMessage = testNode.attributes().message;
                 }
             }
             else if (testCaseNode.error) {
                 outcome = "Failed";
-				var testNode;
-				
-				if(testCaseNode.error.count() > 1){
-					this.command.warning("Multiple failures in the test case: " + testName + ". Picking the first for publishing!");
-					testNode = testCaseNode.error.at(0);
-				}
-				else{
-					testNode = testCaseNode.error;
-				}
-				
+                var testNode;
+
+                if (testCaseNode.error.count() > 1) {
+                    this.command.warning("Multiple failures in the test case: " + testName + ". Picking the first for publishing!");
+                    testNode = testCaseNode.error.at(0);
+                }
+                else {
+                    testNode = testCaseNode.error;
+                }
+
                 if (testNode.text) {
                     stackTrace = testNode.text();
                 }

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -12,8 +12,8 @@ import cm = require('../agent/common');
 import ifm = require('../agent/interfaces');
 import testifm = require('vso-node-api/interfaces/TestInterfaces');
 
-describe('PublisherTests', function() {
-    
+describe('PublisherTests', function () {
+
     var runContext: trp.TestRunContext = {
         requestedFor: "userx",
         buildId: "21",
@@ -24,23 +24,24 @@ describe('PublisherTests', function() {
         fileNumber: "3",
         releaseUri: "abc",
         releaseEnvironmentUri: "xyz"
-    };  
-	
-	var command : cm.ITaskCommand;
-    var readerJUnit = new trr.JUnitResultReader(command);    
+    };
+
+    var command: cm.ITaskCommand;
+    var readerJUnit = new trr.JUnitResultReader(command);
     var readerNUnit = new trr.NUnitResultReader(command);
     var readerXUnit = new trr.XUnitResultReader(command);
 
     var resultsFileJUnit = path.resolve(__dirname, './testresults/junitresults1.xml');
+    var resultstFileJUnitMultiNode = path.resolve(__dirname, './testresults/Junit_test2.xml');
     var resultsFileNUnit = path.resolve(__dirname, './testresults/nunitresults.xml');
     var resultsFileXUnit = path.resolve(__dirname, './testresults/xunitresults.xml');
 
     var feedbackChannel;
     var testRunPublisher;
 
-    it('results.publish : JUnit results file', function(done) {
+    it('results.publish : JUnit results file', function (done) {
         this.timeout(2000);
-        
+
         feedbackChannel = new fm.TestFeedbackChannel();
         testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
 
@@ -48,11 +49,26 @@ describe('PublisherTests', function() {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
             done();
         },
-        function (err) {
-            assert(false, 'ResultPublish Task Failed! Details : '  + err.message);
-        });
-    })    
-        
+            function (err) {
+                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
+            });
+    })
+
+    it('results.publish : JUnit results file with multiple test suite nodes (karma format)', function (done) {
+        this.timeout(2000);
+
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
+
+        testRunPublisher.publishTestRun(resultstFileJUnitMultiNode).then(function (createdTestRun) {
+            assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
+            done();
+        },
+            function (err) {
+                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
+            });
+    })
+
     it('results.publish : NUnit results file', function (done) {
         this.timeout(2000);
         feedbackChannel = new fm.TestFeedbackChannel();
@@ -62,14 +78,14 @@ describe('PublisherTests', function() {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
             done();
         },
-        function (err) {
-            assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
-        });
-    })	
+            function (err) {
+                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
+            });
+    })
 
     it('results.publish : XUnit results file', function (done) {
         this.timeout(2000);
-        
+
         feedbackChannel = new fm.TestFeedbackChannel();
         testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerXUnit);
 
@@ -81,31 +97,31 @@ describe('PublisherTests', function() {
                 assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
             });
     })
-/*
-    it('results.publish : error handling for create test run', function(done) {
-        this.timeout(2000);
-
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
-
-        var testRun: testifm.RunCreateModel = <any>{
-            name: "foobar",
-            id: -1
-        };
-
-        // error handling/propagation from start test run 
-        testRunPublisher.startTestRun(testRun).then(function (createdTestRun) {
-            assert(false, 'ResultPublish Task did not fail as expected');
-            done();
-        },
-        function (err) {
-            assert(err.message == "Too bad - createTestRun failed", 'ResultPublish Task error message does not match expected - ' + err.message);
-            done();
-        });
-
-    })	
-*/      
-    it('results.publish : error handling for end test run', function(done) {
+    /*
+        it('results.publish : error handling for create test run', function(done) {
+            this.timeout(2000);
+    
+            feedbackChannel = new fm.TestFeedbackChannel();
+            testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
+    
+            var testRun: testifm.RunCreateModel = <any>{
+                name: "foobar",
+                id: -1
+            };
+    
+            // error handling/propagation from start test run 
+            testRunPublisher.startTestRun(testRun).then(function (createdTestRun) {
+                assert(false, 'ResultPublish Task did not fail as expected');
+                done();
+            },
+            function (err) {
+                assert(err.message == "Too bad - createTestRun failed", 'ResultPublish Task error message does not match expected - ' + err.message);
+                done();
+            });
+    
+        })	
+    */
+    it('results.publish : error handling for end test run', function (done) {
         this.timeout(2000);
 
         feedbackChannel = new fm.TestFeedbackChannel();
@@ -121,13 +137,13 @@ describe('PublisherTests', function() {
             assert(false, 'ResultPublish Task did not fail as expected');
             done();
         },
-        function (err) {
-            assert(err.message == "Too bad - endTestRun failed", 'ResultPublish Task error message does not match expected - ' + err.message);
-            done();
-        });
-    }) 
-           
-    it('results.publish : error handling for reading results', function(done) {
+            function (err) {
+                assert(err.message == "Too bad - endTestRun failed", 'ResultPublish Task error message does not match expected - ' + err.message);
+                done();
+            });
+    })
+
+    it('results.publish : error handling for reading results', function (done) {
         this.timeout(2000);
 
         feedbackChannel = new fm.TestFeedbackChannel();
@@ -138,18 +154,18 @@ describe('PublisherTests', function() {
         testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
             assert(!feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
         },
-        function (err) {
-            assert(err.message == "Unmatched closing tag: XYZXYZuite\nLine: 13\nColumn: 16\nChar: >",
-                'ResultPublish Task Failed as expected! Details : '  + err.message);
-            done();
-        });
+            function (err) {
+                assert(err.message == "Unmatched closing tag: XYZXYZuite\nLine: 13\nColumn: 16\nChar: >",
+                    'ResultPublish Task Failed as expected! Details : ' + err.message);
+                done();
+            });
     })
 
     it('results.publish : JUnit reader sanity check without run title', function (done) {
 
         var results;
-        var testRun;  
-        
+        var testRun;
+
         runContext.runTitle = "";
         runContext.fileNumber = "0";
 
@@ -174,54 +190,54 @@ describe('PublisherTests', function() {
             assert.strictEqual("should default useDotNotation to true", results[2].automatedTestName);
             done();
         },
-        function(err) {
-            assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-            done();
-        });		
+            function (err) {
+                assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
-    it('results.publish : JUnit reader sanity check with run title', function(done) {
-        
+
+    it('results.publish : JUnit reader sanity check with run title', function (done) {
+
         var testRun;
 
         runContext.runTitle = "My Title";
-        runContext.fileNumber = "0";        
+        runContext.fileNumber = "0";
 
         readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title", testRun.name);			
+            assert.strictEqual("My Title", testRun.name);
             done();
         },
-        function(err) {
-            assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-            done();
-        });		
+            function (err) {
+                assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
-    it('results.publish : JUnit reader sanity check with run title and file number', function(done) {
-        
-        var testRun;        
-        
+
+    it('results.publish : JUnit reader sanity check with run title and file number', function (done) {
+
+        var testRun;
+
         runContext.fileNumber = "3";
 
         readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title 3", testRun.name);			
+            assert.strictEqual("My Title 3", testRun.name);
             done();
         },
-        function(err) {
-            assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-            done();
-        });		
+            function (err) {
+                assert(false, 'JUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
+
     it('results.publish : NUnit reader sanity check without run title', function (done) {
-        
-        var results;        
+
+        var results;
         var testRun;
 
         runContext.runTitle = "";
@@ -249,59 +265,59 @@ describe('PublisherTests', function() {
             assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooShort_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[3].automatedTestName);
             done();
         },
-        function(err) {
-            assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-            done();
-        });
+            function (err) {
+                assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
-    it('results.publish : NUnit reader sanity check with run title', function(done) {
-        
+
+    it('results.publish : NUnit reader sanity check with run title', function (done) {
+
         var testRun;
 
         runContext.runTitle = "My Title";
-        runContext.fileNumber = "0";      
-        
+        runContext.fileNumber = "0";
+
         readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title", testRun.name);			
+            assert.strictEqual("My Title", testRun.name);
             done();
         },
-        function(err) {
-            assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-            done();
-        });		
+            function (err) {
+                assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
-    it('results.publish : NUnit reader sanity check with run title and file number', function(done) {
-        
+
+    it('results.publish : NUnit reader sanity check with run title and file number', function (done) {
+
         var testRun;
         runContext.fileNumber = "3";
-          
+
         readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title 3", testRun.name);			
+            assert.strictEqual("My Title 3", testRun.name);
             done();
         },
-        function(err) {
-            assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-            done();
-        });		
+            function (err) {
+                assert(false, 'NUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
-    
+
+
     it('results.publish : XUnit reader sanity check without run title', function (done) {
 
         var results;
         var testRun;
 
         runContext.runTitle = "";
-        runContext.fileNumber = "0"; 
-               
+        runContext.fileNumber = "0";
+
         readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
             testRun = res.testRun;
             results = res.testResults;
@@ -324,36 +340,36 @@ describe('PublisherTests', function() {
             assert.strictEqual("test1", results[3].automatedTestName);
             done();
         },
-        function(err) {
-            assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-            done();
-        }); 
+            function (err) {
+                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
-    it('results.publish : XUnit reader sanity check with run title', function(done) {
-        
+
+    it('results.publish : XUnit reader sanity check with run title', function (done) {
+
         var testRun;
 
         runContext.runTitle = "My Title";
         runContext.fileNumber = "0";
-        
+
         readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
             testRun = res.testRun;
             
             //Verifying the test run details
-            assert.strictEqual("My Title", testRun.name);			
+            assert.strictEqual("My Title", testRun.name);
             done();
         },
-        function(err) {
-            assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-            done();
-        });		
+            function (err) {
+                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
+                done();
+            });
     })
-    
-    it('results.publish : XUnit reader sanity check with run title and file number', function(done) {
-        
-        var testRun;        
-        
+
+    it('results.publish : XUnit reader sanity check with run title and file number', function (done) {
+
+        var testRun;
+
         runContext.fileNumber = "3";
         readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
             testRun = res.testRun;
@@ -368,6 +384,6 @@ describe('PublisherTests', function() {
             }).fail(function (err) {
                 assert(false, 'XUnit Reader Failed! Details : ' + err.message);
                 done(err);
-            });		
+            });
     })
 });	

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -8,6 +8,7 @@ import path = require('path');
 import fm = require('./lib/feedback');
 import trp = require('../agent/testrunpublisher');
 import trr = require('../agent/testresultreader');
+import cm = require('../agent/common');
 import ifm = require('../agent/interfaces');
 import testifm = require('vso-node-api/interfaces/TestInterfaces');
 
@@ -24,10 +25,11 @@ describe('PublisherTests', function() {
         releaseUri: "abc",
         releaseEnvironmentUri: "xyz"
     };  
-
-    var readerJUnit = new trr.JUnitResultReader();    
-    var readerNUnit = new trr.NUnitResultReader();
-    var readerXUnit = new trr.XUnitResultReader();
+	
+	var command : cm.ITaskCommand;
+    var readerJUnit = new trr.JUnitResultReader(command);    
+    var readerNUnit = new trr.NUnitResultReader(command);
+    var readerXUnit = new trr.XUnitResultReader(command);
 
     var resultsFileJUnit = path.resolve(__dirname, './testresults/junitresults1.xml');
     var resultsFileNUnit = path.resolve(__dirname, './testresults/nunitresults.xml');

--- a/src/test/testresults/Junit_test2.xml
+++ b/src/test/testresults/Junit_test2.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="http://localhost:8000/test/index.html" hostname="localhost" tests="10" failures="5" errors="0" time="0.02" timestamp="2013-03-12T13:11:50Z">
+  <testsuite id="0" name="Module 1" hostname="localhost" tests="5" failures="2" errors="0" time="0.004" timestamp="2013-03-12T13:11:50Z">
+    <testcase name="test 1" tests="2" failures="1" errors="0" time="0.003" timestamp="2013-03-12T13:11:50Z">
+      <failure type="AssertionFailedError" message="Assert fail 1 = 2">
+        <actual value="1" />
+        <expected value="2" />
+      </failure>
+    </testcase>
+    <testcase name="test 2" tests="3" failures="1" errors="0" time="0.001" timestamp="2013-03-12T13:11:50Z">
+      <failure type="AssertionFailedError" message="Assert fail 1 = 2">
+        <actual value="1" />
+        <expected value="2" />
+      </failure>
+    </testcase>
+    <system-out>
+      <![CDATA[
+[Module 1, test 1, 2] Assert fail 1 = 2
+[Module 1, test 2, 2] Assert fail 1 = 2
+]]>
+    </system-out>
+  </testsuite>
+  <testsuite id="1" name="Module 2" hostname="localhost" tests="5" failures="3" errors="0" time="0.001" timestamp="2013-03-12T13:11:50Z">
+    <testcase name="test 3" tests="2" failures="1" errors="0" time="0" timestamp="2013-03-12T13:11:50Z">
+      <failure type="AssertionFailedError" message="Assert fail 1 = 2">
+        <actual value="1" />
+        <expected value="2" />
+      </failure>
+    </testcase>
+    <testcase name="test 4" tests="3" failures="2" errors="0" time="0.001" timestamp="2013-03-12T13:11:50Z">
+      <failure type="AssertionFailedError" message="Assert fail 1 = 2">
+        <actual value="1" />
+        <expected value="2" />
+      </failure>
+      <failure type="AssertionFailedError" message="Assert fail 1 = 3">
+        <actual value="1" />
+        <expected value="3" />
+      </failure>
+    </testcase>
+    <system-out>
+      <![CDATA[
+[Module 2, test 3, 2] Assert fail 1 = 2
+[Module 2, test 4, 2] Assert fail 1 = 2
+[Module 2, test 4, 3] Assert fail 1 = 3
+]]>
+    </system-out>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Description: There are JUnit result files which may have multiple failure and error nodes for a test case. TestResult publishing task was failing with testCaseNode.failure.attributes() is not a function for these result files.

Fix: Handled the case with multiple failure nodes and publishing the first node.

Testing: Manual