### PR TITLE
Resolving to agent node runtime for service install

### DIFF
--- a/src/agent/service.ts
+++ b/src/agent/service.ts
@@ -51,7 +51,8 @@ if (typeof svcinstall[action] !== 'function') {
 }*/
 
 // node is known as nodejs on some *nix installs
-var nodePath = shelljs.which('nodejs') || shelljs.which('node');
+//var nodePath = shelljs.which('nodejs') || shelljs.which('node');
+var nodePath = path.resolve('__dirname/..', 'runtime/node/bin/node')
 var getSvcCfg = function () {
     if (!shelljs.test('-f', _cfgPath)) {
         console.error('Error: not configured as a service.  use install action.');


### PR DESCRIPTION
Instead of using the node in the path this configures the service to use the node that is installed with the agent.