### PR TITLE
Resolve TFVC build server path to local path

### DIFF
--- a/src/agent/scm/lib/tfvcwrapper.ts
+++ b/src/agent/scm/lib/tfvcwrapper.ts
@@ -124,7 +124,11 @@ export class TfvcWrapper extends events.EventEmitter {
     public undo(): Q.Promise<number> {
         return this._exec('undo', ['.', '-recursive']);
     }
-    
+
+    public listWorkspaces() {
+        return this._execSync("workspaces", []);
+    }
+
     public resolvePath(inputPath: string): string {
         if (this._isServerPath(inputPath)) {
             var output = this._execSync('resolvePath', [ inputPath ]);

--- a/src/agent/scm/lib/tfvcwrapper.ts
+++ b/src/agent/scm/lib/tfvcwrapper.ts
@@ -124,6 +124,23 @@ export class TfvcWrapper extends events.EventEmitter {
     public undo(): Q.Promise<number> {
         return this._exec('undo', ['.', '-recursive']);
     }
+    
+    public resolvePath(inputPath: string): string {
+        if (this._isServerPath(inputPath)) {
+            var output = this._execSync('resolvePath', [ inputPath ]);
+            if (this._success(output)) {
+                return output.stdout.toString();
+            } 
+        }
+
+        // if we failed to resolve the path (maybe it wasn't a server path, maybe the path isn't mapped)
+        // just return the input.  This way we honor any relative path user has manually typed in
+        return inputPath;
+    } 
+    
+    private _isServerPath(inputPath: string): boolean {
+        return  inputPath !== ""  && inputPath.charAt(0) === '$'; 
+    }
 
     private _getQuotedArgsWithDefaults(args: string[]): string[] {
         // default connection related args
@@ -149,15 +166,57 @@ export class TfvcWrapper extends events.EventEmitter {
 
         return msg;
     }
+    
+    private _getToolRunner(cmd: string, args: string[]) {
+        var tf = new tl.ToolRunner(this.tfPath);
+        tf.silent = true;
+        
+        // cmd
+        tf.arg(cmd, true);
 
+        var quotedArgs = this._getQuotedArgsWithDefaults(args);
+        // args
+        if (quotedArgs.map((arg: string) => {
+            tf.arg(arg, true); // raw arg
+        }));
+        
+        return tf;
+    }
+    
+    private _getOpts(options?: ITfvcExecOptions) {             
+        var options = options || <ITfvcExecOptions>{};
+        var ops: any = {
+            cwd: options.cwd || process.cwd(),
+            env: options.env || process.env,
+            silent: true,
+            outStream: options.outStream || process.stdout,
+            errStream: options.errStream || process.stderr,
+            failOnStdErr: options.failOnStdErr || false,
+            ignoreReturnCode: options.ignoreReturnCode || false
+        };
+        
+        return ops;
+    }
+    
+    private _execSync(cmd: string, args: string[], options?: ITfvcExecOptions) {
+        if (this.tfPath === null) {
+            return this._getTfNotInstalled();
+        }
+        
+        var tf = this._getToolRunner(cmd, args);
+        var ops = this._getOpts(options);
+        
+        return tf.execSync(ops);
+    }
+    
     private _exec(cmd: string, args: string[], options?: ITfvcExecOptions): Q.Promise<number> {
         if (this.tfPath === null) {
             return this._getTfNotInstalled();
         }
-
-        var tf = new tl.ToolRunner(this.tfPath);
-        tf.silent = true;
-
+        
+        var tf = this._getToolRunner(cmd, args);
+        var ops = this._getOpts(options);
+      
         tf.on('debug', (message) => {
             this.emit('stdout', '[debug]' + this._scrubCredential(message));
         })
@@ -169,26 +228,6 @@ export class TfvcWrapper extends events.EventEmitter {
         tf.on('stderr', (data) => {
             this.emit('stderr', this._scrubCredential(data));
         })
-
-        // cmd
-        tf.arg(cmd, true);
-
-        var quotedArgs = this._getQuotedArgsWithDefaults(args);
-        // args
-        if (quotedArgs.map((arg: string) => {
-            tf.arg(arg, true); // raw arg
-        }));
-
-        options = options || <ITfvcExecOptions>{};
-        var ops: any = {
-            cwd: options.cwd || process.cwd(),
-            env: options.env || process.env,
-            silent: true,
-            outStream: options.outStream || process.stdout,
-            errStream: options.errStream || process.stderr,
-            failOnStdErr: options.failOnStdErr || false,
-            ignoreReturnCode: options.ignoreReturnCode || false
-        };
 
         return tf.exec(ops);
     }

--- a/src/agent/scm/tfsversioncontrol.ts
+++ b/src/agent/scm/tfsversioncontrol.ts
@@ -243,6 +243,12 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
             }
         })
         .then(() => {
+            // Sometime the job fails with:
+            //   An argument error occurred: Unable to determine the workspace. 
+            //   You may be able to correct this by running 'tf workspaces -collection:TeamProjectCollectionUrl'.
+            // when getting the source.  Preemptively run this to be safe.
+            this.tfvcw.listWorkspaces();
+
             // now it's guaranteed build definition mapping and actual workspace mapping are identical
             var getCodePromiseChain = Q(0);
 

--- a/src/agent/scm/tfsversioncontrol.ts
+++ b/src/agent/scm/tfsversioncontrol.ts
@@ -73,6 +73,14 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
             collection: collectionUri
         });
     }
+    
+    public resolveInputPath(inputPath: string) {
+        this.ctx.debug("Resolving: " + inputPath);
+        var resolvedPath = this.tfvcw.resolvePath(inputPath);
+        this.ctx.debug("    resolved to: " + resolvedPath);
+
+        return resolvedPath;
+    }
 
     public getCode(): Q.Promise<number> {
         var workspaceName = this._getWorkspaceName();

--- a/src/agent/scm/tfsversioncontrol.ts
+++ b/src/agent/scm/tfsversioncontrol.ts
@@ -110,7 +110,9 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
             // hopefully mappings are short lists so a naive comparison isn't too terriably slow
             var contains = function(m: tfvcwm.TfvcMapping, mArray: tfvcwm.TfvcMapping[]): boolean {
                 for(var i = 0; i < mArray.length; i++) {
-                    if (m.type === mArray[i].type && m.serverPath === mArray[i].serverPath) {
+                    if (m.type === mArray[i].type 
+                            && m.serverPath === mArray[i].serverPath
+                            && m.localPath === mArray[i].localPath) {
                         return true; 
                     } 
                 }
@@ -358,10 +360,16 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
         return commonPath;
     }
 
-    private _createLocalPath(mapping: string, commonPath: string): string {
+    private _createLocalPath(mapping, commonPath: string): string {
         var serverPath = mapping["serverPath"];
-        var rootedServerPath = this._rootingWildcardPath(serverPath.slice(commonPath.length));
-        var localPath = path.join(this.targetPath, rootedServerPath); 
+        var localPath;
+        if (mapping["localPath"]) {
+            this.ctx.debug("Use localPath defined in build definition");
+            localPath = path.join(this.targetPath, mapping["localPath"].replace(/\\/g, "/")); 
+        } else {
+            var rootedServerPath = this._rootingWildcardPath(serverPath.slice(commonPath.length));
+            localPath = path.join(this.targetPath, rootedServerPath); 
+        }
 
         this._ensurePathExist(localPath);
 
@@ -373,7 +381,7 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
             var tfvcMappings = JSON.parse(endpoint.data['tfvcWorkspaceMapping']);
             if (tfvcMappings && tfvcMappings.mappings) {
                 var commonRootPath = this._getCommonRootPath(tfvcMappings.mappings);
-                this.ctx.info('common path for mapping: ' + commonRootPath);
+                this.ctx.debug('common path for mapping: ' + commonRootPath);
                 return tfvcMappings.mappings.map((buildDefMap) => {
                     var serverPath = buildDefMap["serverPath"];
                     return <tfvcwm.TfvcMapping>{


### PR DESCRIPTION
I moved the block that resolves input path after getCode() call, otherwise we haven't create any workspace so TFVC can't resolve the path.  

If user selected a server path from the path picker, we will attempt to
use tf's resolvePath command to resolve the server path to a local path.
If resolution isn't possible (tf doesn't have the cmd, the input path
is not a server path, or the server path hasn't been mapped yet), we
will return the input.  This way we could still honor any relative path
the customer has entered themselves.