### PR TITLE
Cloak doesn't define localPath; shelveset requires workspace to resolve path.

### DIFF
--- a/src/agent/scm/lib/tfvcwrapper.ts
+++ b/src/agent/scm/lib/tfvcwrapper.ts
@@ -129,9 +129,9 @@ export class TfvcWrapper extends events.EventEmitter {
         return this._execSync("workspaces", []);
     }
 
-    public resolvePath(inputPath: string): string {
+    public resolvePath(inputPath: string, workspaceName: string): string {
         if (this._isServerPath(inputPath)) {
-            var output = this._execSync('resolvePath', [ inputPath ]);
+            var output = this._execSync('resolvePath', [ inputPath, '-workspace:' + workspaceName ]);
             if (this._success(output)) {
                 return output.stdout.toString();
             } 

--- a/src/agent/scm/tfsversioncontrol.ts
+++ b/src/agent/scm/tfsversioncontrol.ts
@@ -76,7 +76,7 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
     
     public resolveInputPath(inputPath: string) {
         this.ctx.debug("Resolving: " + inputPath);
-        var resolvedPath = this.tfvcw.resolvePath(inputPath);
+        var resolvedPath = this.tfvcw.resolvePath(inputPath, this._getWorkspaceName());
         this.ctx.debug("    resolved to: " + resolvedPath);
 
         return resolvedPath;
@@ -110,11 +110,11 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
             // hopefully mappings are short lists so a naive comparison isn't too terriably slow
             var contains = function(m: tfvcwm.TfvcMapping, mArray: tfvcwm.TfvcMapping[]): boolean {
                 for(var i = 0; i < mArray.length; i++) {
-                    if (m.type === mArray[i].type 
-                            && m.serverPath === mArray[i].serverPath
-                            && m.localPath === mArray[i].localPath) {
-                        return true; 
-                    } 
+                    if (m.type === mArray[i].type && m.serverPath === mArray[i].serverPath) {
+                        if (m.type === 'cloak' || m.localPath === mArray[i].localPath) {
+                            return true; 
+                        }
+                    }
                 }
 
                 return false;
@@ -370,7 +370,7 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
         var serverPath = mapping["serverPath"];
         var localPath;
         if (mapping["localPath"]) {
-            this.ctx.debug("Use localPath defined in build definition");
+            this.ctx.debug("Use localPath defined in build definition: " + mapping["localPath"]);
             localPath = path.join(this.targetPath, mapping["localPath"].replace(/\\/g, "/")); 
         } else {
             var rootedServerPath = this._rootingWildcardPath(serverPath.slice(commonPath.length));


### PR DESCRIPTION
Fixing two issues with latest tfvc xplat agent code:
1. Cloak doesn't define localpath, so any naïve comparison against localpath will always result in recreate workspace.
2. Once we unshelved  some code to current workspace, we must pass the "workspace" option to get the server path resolved.  