### PR TITLE
Fix couple more path issues

### DIFF
--- a/src/agent/scm/lib/tfvcwrapper.ts
+++ b/src/agent/scm/lib/tfvcwrapper.ts
@@ -241,7 +241,7 @@ export class TfvcWrapper extends events.EventEmitter {
             return this._getTfNotInstalled();
         }
 
-        var cmdline = 'tf ' + cmd + ' ' + this._getQuotedArgsWithDefaults(args).join(' ');
+        var cmdline = this.tfPath + ' ' + cmd + ' ' + this._getQuotedArgsWithDefaults(args).join(' ');
         return utilm.exec(cmdline);
     }
 

--- a/src/agent/scm/tfsversioncontrol.ts
+++ b/src/agent/scm/tfsversioncontrol.ts
@@ -111,7 +111,7 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
             var contains = function(m: tfvcwm.TfvcMapping, mArray: tfvcwm.TfvcMapping[]): boolean {
                 for(var i = 0; i < mArray.length; i++) {
                     if (m.type === mArray[i].type && m.serverPath === mArray[i].serverPath) {
-                        if (m.type === 'cloak' || m.localPath === mArray[i].localPath) {
+                        if (m.type === 'cloak' || path.resolve(m.localPath) === path.resolve(mArray[i].localPath)) {
                             return true; 
                         }
                     }


### PR DESCRIPTION
1. Can't assume 'tf' is on PATH anymore since we pack our own
2. Can't assume local paths from build definition are the same since
   user can add slashes at the end.  The path resolved by tf
   don't have any slashes, and they don't match. If they don't match,
   we remap and force a clean build.