### PR TITLE
#253 - Update TestResultReader.ts to Handle jUnit Results with Empty Suites

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,7 @@ gulp.task('build', ['copy'], function () {
         .pipe(gulp.dest(buildPath));
 });
 
-gulp.task('testPrep', function () {
+gulp.task('testPrep', ['build'], function () {
     var buildSrc = gulp.src([path.join(buildPath, '**')]);
     var testSrcPaths = ['src/test/messages/**',
         'src/test/projects/**',
@@ -99,4 +99,4 @@ gulp.task('clean', function (done) {
     del([buildRoot, tarRoot, packageRoot, testRoot], done);
 });
 
-gulp.task('default', ['tar']);
+gulp.task('default', ['tar', 'test']);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "./bin/install.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -150,20 +150,16 @@ export class HostContext extends Context implements cm.IHostContext {
     public workFolder: string;
     
     constructor(config: cm.IConfiguration, fileWriter: cm.IDiagnosticWriter, consoleOutput: boolean) {
-        this.config = config;
-        this.workFolder = cm.getWorkPath(config);
-        
-        ensureTrace(this);
-        
-        this._fileWriter = fileWriter;
-        
-        var writers: cm.IDiagnosticWriter[] = [this._fileWriter];
-        
+        var writers: cm.IDiagnosticWriter[] = [fileWriter];
         if (consoleOutput) {
             writers.push(new dm.DiagnosticConsoleWriter(cm.DiagnosticLevel.Status));
-        }
-        
+        }        
         super(writers);
+        
+        this.config = config;
+        this.workFolder = cm.getWorkPath(config);
+        this._fileWriter = fileWriter;        
+        ensureTrace(this);     
     }
     
     public trace(message: string): void {
@@ -180,6 +176,18 @@ export class ExecutionContext extends Context implements cm.IExecutionContext {
 
         ensureTrace(hostContext);
         trace.enter('ExecutionContext');
+        
+        function createLogger() {
+            const debugOutput = jobInfo.variables[cm.vars.systemDebug] == 'true';        
+            const logger: lm.PagingLogger = new lm.PagingLogger(logFolder, logData);
+            logger.level =  debugOutput ? cm.DiagnosticLevel.Verbose : cm.DiagnosticLevel.Info;
+            logger.on('pageComplete', (info: cm.ILogPageInfo) => {
+                service.queueLogPage(info);
+            });
+            return logger;
+        }
+        
+        super([createLogger()]);
 
         this.jobInfo = jobInfo;
         this.authHandler = authHandler;
@@ -200,19 +208,8 @@ export class ExecutionContext extends Context implements cm.IExecutionContext {
         logData.recordId = recordId;
 
         this.debugOutput = this.variables[cm.vars.systemDebug] == 'true';
-        var logger: lm.PagingLogger = new lm.PagingLogger(logFolder, logData);
-
-        logger.level =  this.debugOutput ? cm.DiagnosticLevel.Verbose : cm.DiagnosticLevel.Info;
-
-        logger.on('pageComplete', (info: cm.ILogPageInfo) => {
-            service.queueLogPage(info);
-        });
-
         this.util = new um.Utilities(this);
-
         this.scmPath = path.join(__dirname, 'scm');
-
-        super([logger]);
     }
 
     public traceWriter: cm.ITraceWriter;

--- a/src/agent/scm/git.ts
+++ b/src/agent/scm/git.ts
@@ -27,7 +27,8 @@ function _translateRef(ref) {
 // TODO: take options with stdout and stderr streams for testing?
 
 export class GitScmProvider extends scmm.ScmProvider {
-	constructor(ctx: cm.IExecutionContext, endpoint: agentifm.ServiceEndpoint) {
+	constructor(ctx: cm.IExecutionContext, endpoint: agentifm.ServiceEndpoint) {        
+		super(ctx, endpoint);
 		this.gitw = new gitwm.GitWrapper();
 		this.gitw.on('stdout', (data) => {
 			ctx.info(data.toString());
@@ -36,8 +37,6 @@ export class GitScmProvider extends scmm.ScmProvider {
 		this.gitw.on('stderr', (data) => {
 			ctx.info(data.toString());
 		});
-
-		super(ctx, endpoint);
 	}
 
 	public username: string;

--- a/src/agent/scm/svn.ts
+++ b/src/agent/scm/svn.ts
@@ -14,7 +14,8 @@ export function getProvider(ctx: cm.IExecutionContext, endpoint: agentifm.Servic
 }
 
 export class SvnScmProvider extends scmprovider.ScmProvider {
-    constructor(ctx: cm.IExecutionContext, endpoint: agentifm.ServiceEndpoint) {
+    constructor(ctx: cm.IExecutionContext, endpoint: agentifm.ServiceEndpoint) {        
+        super(ctx, endpoint);
         this.svnw = new sw.SvnWrapper(ctx);
         this.svnw.on('stdout', (data) => {
             ctx.info(data.toString());
@@ -25,8 +26,6 @@ export class SvnScmProvider extends scmprovider.ScmProvider {
         });
         
         this.environmentVariables = this._getEnvironmentVariables(ctx);
-
-        super(ctx, endpoint);
     }
 
     public svnw: sw.SvnWrapper;

--- a/src/agent/scm/tfsversioncontrol.ts
+++ b/src/agent/scm/tfsversioncontrol.ts
@@ -14,7 +14,8 @@ export function getProvider(ctx: cm.IExecutionContext, endpoint: agentifm.Servic
 }
 
 export class TfsvcScmProvider extends scmm.ScmProvider {
-    constructor(ctx: cm.IExecutionContext, endpoint: agentifm.ServiceEndpoint) {
+    constructor(ctx: cm.IExecutionContext, endpoint: agentifm.ServiceEndpoint) {        
+        super(ctx, endpoint);
         this.tfvcw = new tfvcwm.TfvcWrapper();
         this.tfvcw.on('stdout', (data) => {
             ctx.info(data.toString());
@@ -23,9 +24,7 @@ export class TfsvcScmProvider extends scmm.ScmProvider {
         this.tfvcw.on('stderr', (data) => {
             ctx.info(data.toString());
         });
-
-        super(ctx, endpoint);
-
+        
         this.version = this.ctx.jobInfo.jobMessage.environment.variables['build.sourceVersion'];
         this.shelveset = this.ctx.jobInfo.jobMessage.environment.variables['build.sourceTfvcShelveset'];
     }

--- a/src/agent/testresultreader.ts
+++ b/src/agent/testresultreader.ts
@@ -138,7 +138,6 @@ export class ResultReader {
         else {
             return null;
         }
-
     }
 
     private parseJUnitXml(res, runContext, file) {
@@ -231,7 +230,9 @@ export class ResultReader {
         
         function extractTestResult(testCaseNode): testifm.TestResultCreateModel {
             function pickFirst(type: string) {
-                if (testCaseNode[type].count() > 1) {
+                if (!testCaseNode.hasOwnProperty(type)) {
+                    throw new Error("Cannot pick first element of type " + type);
+                } else if (testCaseNode[type].count() > 1) {
                     if (this.command) {                        
                         this.command.info("Multiple " + type + "s in the test case: " + testName + ". Picking the first for publishing!");
                     }

--- a/src/test/lib/feedback.ts
+++ b/src/test/lib/feedback.ts
@@ -228,19 +228,19 @@ export class TestFeedbackChannel extends events.EventEmitter implements cm.IServ
     //------------------------------------------------------------------  
     public initializeTestManagement(projectName: string): void {
         var record = this._getFromBatch("1.createTestRun");
-        record.result = agentifm.TaskResult.Failed;
+        record.result = agentifm.TaskResult.Succeeded;
         record.state = agentifm.TimelineRecordState.Completed;
 
         var record = this._getFromBatch("2.createTestRunAttachment");
-        record.result = agentifm.TaskResult.Failed;
+        record.result = agentifm.TaskResult.Succeeded;
         record.state = agentifm.TimelineRecordState.Completed;
 
         var record = this._getFromBatch("3.createTestRunResult");
-        record.result = agentifm.TaskResult.Failed;
+        record.result = agentifm.TaskResult.Succeeded;
         record.state = agentifm.TimelineRecordState.Completed;
 
         var record = this._getFromBatch("4.endTestRun");
-        record.result = agentifm.TaskResult.Failed;
+        record.result = agentifm.TaskResult.Succeeded;
         record.state = agentifm.TimelineRecordState.Completed;
     }
 

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -297,7 +297,7 @@ describe('PublisherTests', function () {
 
         return testRunPublisher.publishMergedTestRun([resultsFileJUnit, resultsFileJUnit2]).then(createTestRun => {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-        }).catch(err => console.log("ERROR", err));
+        });
     })
 
     it('results.publish : NUnit results file with merge support', () => {

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -33,6 +33,7 @@ describe('PublisherTests', function () {
 
     var resultsFileJUnit = path.resolve(__dirname, './testresults/junitresults1.xml');
     var resultstFileJUnitMultiNode = path.resolve(__dirname, './testresults/Junit_test2.xml');
+    var resultsFileJUnitEmptySuite = path.resolve(__dirname, './testresults/junit_with_empty_suite.xml');
     var resultsFileNUnit = path.resolve(__dirname, './testresults/nunitresults.xml');
     var resultsFileXUnit = path.resolve(__dirname, './testresults/xunitresults.xml');
 
@@ -66,6 +67,20 @@ describe('PublisherTests', function () {
         },
             function (err) {
                 assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
+            });
+    })
+    
+    it('results.publish : JUnit results file with empty suites', function (done) {
+        feedbackChannel = new fm.TestFeedbackChannel();
+        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
+
+        testRunPublisher.publishTestRun(resultsFileJUnitEmptySuite).then(function (createdTestRun) {
+            assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
+            done();
+        },
+            function (err) {
+                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
+                done();
             });
     })
 

--- a/src/test/publishertests.ts
+++ b/src/test/publishertests.ts
@@ -12,9 +12,12 @@ import cm = require('../agent/common');
 import ifm = require('../agent/interfaces');
 import testifm = require('vso-node-api/interfaces/TestInterfaces');
 
-describe('PublisherTests', function () {
+function resultFile(filename: string) {
+    return path.resolve(__dirname, 'testresults', filename);
+}
 
-    var runContext: trp.TestRunContext = {
+describe('PublisherTests', function () {
+    const runContext: trp.TestRunContext = {
         requestedFor: "userx",
         buildId: "21",
         platform: "mac",
@@ -26,121 +29,75 @@ describe('PublisherTests', function () {
         releaseEnvironmentUri: "xyz"
     };
 
-    var command: cm.ITaskCommand;
-    var readerJUnit = new trr.JUnitResultReader(command);
-    var readerNUnit = new trr.NUnitResultReader(command);
-    var readerXUnit = new trr.XUnitResultReader(command);
+    let command: cm.ITaskCommand;
+    const readerJUnit = new trr.JUnitResultReader(command);
+    const readerNUnit = new trr.NUnitResultReader(command);
+    const readerXUnit = new trr.XUnitResultReader(command);
 
-    var resultsFileJUnit = path.resolve(__dirname, './testresults/junitresults1.xml');
-    var resultstFileJUnitMultiNode = path.resolve(__dirname, './testresults/Junit_test2.xml');
-    var resultsFileJUnitEmptySuite = path.resolve(__dirname, './testresults/junit_with_empty_suite.xml');
-    var resultsFileNUnit = path.resolve(__dirname, './testresults/nunitresults.xml');
-    var resultsFileXUnit = path.resolve(__dirname, './testresults/xunitresults.xml');
+    const resultsFileJUnit = resultFile('junitresults1.xml');
+    const resultstFileJUnitMultiNode = resultFile('Junit_test2.xml');
+    const resultsFileJUnitNoTestCases = resultFile('junit_with_no_test_cases.xml');
+    const resultsFileJUnitNoTestSuites = resultFile('junit_with_no_test_suites.xml');
+    const resultsFileNUnit = resultFile('nunitresults.xml');
+    const resultsFileXUnit = resultFile('xunitresults.xml');
 
-    var feedbackChannel;
-    var testRunPublisher;
+    it('results.publish : JUnit results file', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
 
-    it('results.publish : JUnit results file', function (done) {
-        this.timeout(2000);
-
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
-
-        testRunPublisher.publishTestRun(resultsFileJUnit).then(function (createdTestRun) {
+        return testRunPublisher.publishTestRun(resultsFileJUnit).then(createdTestRun => {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-            done();
-        },
-            function (err) {
-                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
-            });
-    })
+        });
+    });
 
-    it('results.publish : JUnit results file with multiple test suite nodes (karma format)', function (done) {
-        this.timeout(2000);
+    it('results.publish : JUnit results file with multiple test suite nodes (karma format)', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
 
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
-
-        testRunPublisher.publishTestRun(resultstFileJUnitMultiNode).then(function (createdTestRun) {
+        return testRunPublisher.publishTestRun(resultstFileJUnitMultiNode).then(createdTestRun => {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-            done();
-        },
-            function (err) {
-                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
-            });
-    })
+        });
+    });
     
-    it('results.publish : JUnit results file with empty suites', function (done) {
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
+    it('results.publish : JUnit results file with a suite and no cases', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
 
-        testRunPublisher.publishTestRun(resultsFileJUnitEmptySuite).then(function (createdTestRun) {
+        return testRunPublisher.publishTestRun(resultsFileJUnitNoTestCases).then(createdTestRun => {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-            done();
-        },
-            function (err) {
-                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
+    
+    it('results.publish : JUnit results file with no suites', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
 
-    it('results.publish : NUnit results file', function (done) {
-        this.timeout(2000);
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerNUnit);
-
-        testRunPublisher.publishTestRun(resultsFileNUnit).then(function (createdTestRun) {
+        return testRunPublisher.publishTestRun(resultsFileJUnitNoTestSuites).then(createdTestRun => {
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-            done();
-        },
-            function (err) {
-                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
-            });
-    })
+        });
+    });
 
-    it('results.publish : XUnit results file', function (done) {
-        this.timeout(2000);
+    it('results.publish : NUnit results file', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerNUnit);
 
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerXUnit);
-
-        testRunPublisher.publishTestRun(resultsFileXUnit).then(function (createdTestRun) {
+        return testRunPublisher.publishTestRun(resultsFileNUnit).then(createdTestRun =>{
             assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-            done();
-        },
-            function (err) {
-                assert(false, 'ResultPublish Task Failed! Details : ' + err.message);
-            });
-    })
-    /*
-        it('results.publish : error handling for create test run', function(done) {
-            this.timeout(2000);
-    
-            feedbackChannel = new fm.TestFeedbackChannel();
-            testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
-    
-            var testRun: testifm.RunCreateModel = <any>{
-                name: "foobar",
-                id: -1
-            };
-    
-            // error handling/propagation from start test run 
-            testRunPublisher.startTestRun(testRun).then(function (createdTestRun) {
-                assert(false, 'ResultPublish Task did not fail as expected');
-                done();
-            },
-            function (err) {
-                assert(err.message == "Too bad - createTestRun failed", 'ResultPublish Task error message does not match expected - ' + err.message);
-                done();
-            });
-    
-        })	
-    */
-    it('results.publish : error handling for end test run', function (done) {
-        this.timeout(2000);
+        });
+    });
 
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
+    it('results.publish : XUnit results file', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerXUnit);
+
+        return testRunPublisher.publishTestRun(resultsFileXUnit).then(createdTestRun => {
+            assert(feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
+        });
+    });
+    
+    it('results.publish : error handling for end test run', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
         var testRun = {
             name: "foobar",
             id: -1,
@@ -148,43 +105,37 @@ describe('PublisherTests', function () {
         };
 
         // error handling/propagation from end test run 
-        testRunPublisher.endTestRun(testRun.id, testRun.resultsFile).then(function (createdTestRun) {
-            assert(false, 'ResultPublish Task did not fail as expected');
-            done();
-        },
-            function (err) {
-                assert(err.message == "Too bad - endTestRun failed", 'ResultPublish Task error message does not match expected - ' + err.message);
-                done();
-            });
-    })
+        return testRunPublisher.endTestRun(testRun.id, testRun.resultsFile)
+        .then(createdTestRun => assert(false, 'ResultPublish Task did not fail as expected'))
+        .catch(err => {
+            assert(err.message == "Too bad - endTestRun failed", 'ResultPublish Task error message does not match expected - ' + err.message);
+        });
+    });
 
-    it('results.publish : error handling for reading results', function (done) {
-        this.timeout(2000);
-
-        feedbackChannel = new fm.TestFeedbackChannel();
-        testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
+    it('results.publish : error handling for reading results', () => {
+        const feedbackChannel = new fm.TestFeedbackChannel();
+        const testRunPublisher = new trp.TestRunPublisher(feedbackChannel, null, "teamProject", runContext, readerJUnit);
         
         // error handling/propagation from parsing failures of junit/nunit files
         var resultsFile = path.resolve(__dirname, './testresults/junit_bad.xml');
-        testRunPublisher.publishTestRun(resultsFile).then(function (createdTestRun) {
+        return testRunPublisher.publishTestRun(resultsFile)
+        .then(createdTestRun => {
             assert(!feedbackChannel.jobsCompletedSuccessfully(), 'ResultPublish Task Failed! Details : ' + feedbackChannel.getRecordsString());
-        },
-            function (err) {
-                assert(err.message == "Unmatched closing tag: XYZXYZuite\nLine: 13\nColumn: 16\nChar: >",
+        })
+        .catch(err => {
+            assert(err.message == "Unmatched closing tag: XYZXYZuite\nLine: 13\nColumn: 16\nChar: >",
                     'ResultPublish Task Failed as expected! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : JUnit reader sanity check without run title', function (done) {
-
+    it('results.publish : JUnit reader sanity check without run title', () => {
         var results;
         var testRun;
 
         runContext.runTitle = "";
         runContext.fileNumber = "0";
 
-        readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
+        return readerJUnit.readResults(resultsFileJUnit, runContext).then(res => {
             testRun = res.testRun;
             results = res.testResults;
             
@@ -203,62 +154,44 @@ describe('PublisherTests', function () {
             assert.strictEqual("should default path to an empty string", results[0].automatedTestName);
             assert.strictEqual("should default consolidate to true", results[1].automatedTestName);
             assert.strictEqual("should default useDotNotation to true", results[2].automatedTestName);
-            done();
-        },
-            function (err) {
-                assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : JUnit reader sanity check with run title', function (done) {
-
+    it('results.publish : JUnit reader sanity check with run title', () => {
         var testRun;
 
         runContext.runTitle = "My Title";
         runContext.fileNumber = "0";
 
-        readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
+        return readerJUnit.readResults(resultsFileJUnit, runContext).then(res => {
             testRun = res.testRun;
             
             //Verifying the test run details
             assert.strictEqual("My Title", testRun.name);
-            done();
-        },
-            function (err) {
-                assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : JUnit reader sanity check with run title and file number', function (done) {
-
+    it('results.publish : JUnit reader sanity check with run title and file number', () => {
         var testRun;
 
         runContext.fileNumber = "3";
 
-        readerJUnit.readResults(resultsFileJUnit, runContext).then(function (res) {
+        return readerJUnit.readResults(resultsFileJUnit, runContext).then(res => {
             testRun = res.testRun;
             
             //Verifying the test run details
             assert.strictEqual("My Title 3", testRun.name);
-            done();
-        },
-            function (err) {
-                assert(false, 'JUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : NUnit reader sanity check without run title', function (done) {
-
+    it('results.publish : NUnit reader sanity check without run title', () => {
         var results;
         var testRun;
 
         runContext.runTitle = "";
         runContext.fileNumber = "0";
 
-        readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
+        return readerNUnit.readResults(resultsFileNUnit, runContext).then(res => {
             testRun = res.testRun;
             results = res.testResults;
             
@@ -278,62 +211,44 @@ describe('PublisherTests', function () {
             assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_IsBlank_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[1].automatedTestName);
             assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooLong_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[2].automatedTestName);
             assert.strictEqual("CreditCardValidation.Tests.ValidateCreditCardTests.CreditCardNumber_TooShort_DisplayErrorMessage(Android)_lg_nexus_5_4_4_4", results[3].automatedTestName);
-            done();
-        },
-            function (err) {
-                assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : NUnit reader sanity check with run title', function (done) {
-
+    it('results.publish : NUnit reader sanity check with run title', () => {
         var testRun;
 
         runContext.runTitle = "My Title";
         runContext.fileNumber = "0";
 
-        readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
+        return readerNUnit.readResults(resultsFileNUnit, runContext).then(res => {
             testRun = res.testRun;
             
             //Verifying the test run details
             assert.strictEqual("My Title", testRun.name);
-            done();
-        },
-            function (err) {
-                assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : NUnit reader sanity check with run title and file number', function (done) {
-
+    it('results.publish : NUnit reader sanity check with run title and file number', () => {
         var testRun;
         runContext.fileNumber = "3";
 
-        readerNUnit.readResults(resultsFileNUnit, runContext).then(function (res) {
+        return readerNUnit.readResults(resultsFileNUnit, runContext).then(res => {
             testRun = res.testRun;
             
             //Verifying the test run details
             assert.strictEqual("My Title 3", testRun.name);
-            done();
-        },
-            function (err) {
-                assert(false, 'NUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
 
-    it('results.publish : XUnit reader sanity check without run title', function (done) {
-
+    it('results.publish : XUnit reader sanity check without run title', () => {
         var results;
         var testRun;
 
         runContext.runTitle = "";
         runContext.fileNumber = "0";
 
-        readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
+        return readerXUnit.readResults(resultsFileXUnit, runContext).then(res => {
             testRun = res.testRun;
             results = res.testResults;
             
@@ -353,52 +268,32 @@ describe('PublisherTests', function () {
             assert.strictEqual("PassingTest", results[1].automatedTestName);
             assert.strictEqual("tset2", results[2].automatedTestName);
             assert.strictEqual("test1", results[3].automatedTestName);
-            done();
-        },
-            function (err) {
-                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : XUnit reader sanity check with run title', function (done) {
-
+    it('results.publish : XUnit reader sanity check with run title', () => {
         var testRun;
 
         runContext.runTitle = "My Title";
         runContext.fileNumber = "0";
 
-        readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
+        return readerXUnit.readResults(resultsFileXUnit, runContext).then(res => {
             testRun = res.testRun;
             
             //Verifying the test run details
             assert.strictEqual("My Title", testRun.name);
-            done();
-        },
-            function (err) {
-                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-                done();
-            });
-    })
+        });
+    });
 
-    it('results.publish : XUnit reader sanity check with run title and file number', function (done) {
-
+    it('results.publish : XUnit reader sanity check with run title and file number', () => {
         var testRun;
 
         runContext.fileNumber = "3";
-        readerXUnit.readResults(resultsFileXUnit, runContext).then(function (res) {
+        return readerXUnit.readResults(resultsFileXUnit, runContext).then(res => {
             testRun = res.testRun;
             
             //Verifying the test run details
             assert.strictEqual("My Title 3", testRun.name);
-            done();
-        },
-            function (err) {
-                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-                done(err);
-            }).fail(function (err) {
-                assert(false, 'XUnit Reader Failed! Details : ' + err.message);
-                done(err);
-            });
-    })
+        });
+    });
 });	

--- a/src/test/testresults/junit_with_empty_suite.xml
+++ b/src/test/testresults/junit_with_empty_suite.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="0.9590000000000001" tests="36" failures="0">
+  <testsuite name="Root Suite" timestamp="2016-03-14T22:43:41" tests="0" failures="0" time="0">
+  </testsuite>
+  <testsuite name="Application" timestamp="2016-03-14T22:43:41" tests="1" failures="0" time="0">
+    <testcase name="Root Suite Application Works Okay" time="0" classname="worksOkay">
+    </testcase>
+  </testsuite>  
+</testsuites>

--- a/src/test/testresults/junit_with_no_test_cases.xml
+++ b/src/test/testresults/junit_with_no_test_cases.xml
@@ -2,8 +2,4 @@
 <testsuites name="Mocha Tests" time="0.9590000000000001" tests="36" failures="0">
   <testsuite name="Root Suite" timestamp="2016-03-14T22:43:41" tests="0" failures="0" time="0">
   </testsuite>
-  <testsuite name="Application" timestamp="2016-03-14T22:43:41" tests="1" failures="0" time="0">
-    <testcase name="Root Suite Application Works Okay" time="0" classname="worksOkay">
-    </testcase>
-  </testsuite>  
 </testsuites>

--- a/src/test/testresults/junit_with_no_test_suites.xml
+++ b/src/test/testresults/junit_with_no_test_suites.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Mocha Tests" time="0.9590000000000001" tests="36" failures="0">
+  <testsuite name="Root Suite" timestamp="2016-03-14T22:43:41" tests="0" failures="0" time="0">
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
This gist of this fix is basically on this line: https://github.com/Microsoft/vso-agent/compare/master...darthtrevino:master#diff-c239605f4d523f5bd8f9cd70928887daR337

The code that was executed per child node was looking a little scary, cyclomatic-complexity wise, so I did a very minor function extraction.

Closes #253 