### PR TITLE
Resolve the archive creation properly

### DIFF
--- a/src/agent/utilities.ts
+++ b/src/agent/utilities.ts
@@ -256,19 +256,25 @@ export function readDirectory(directory: string, includeFiles: boolean, includeF
 
 export function archiveFiles(files: string[], archiveName: string): Q.Promise<string> {
     var defer = Q.defer<string>();
-
     var archive = path.join(shell.tempdir(), archiveName);
     var output = fs.createWriteStream(archive);
     var zipper = archiver('zip');
-    
+
+    output.on('close', function() {
+        defer.resolve(archive);
+    });
+    zipper.on('error', function(err) {
+        defer.reject(err);
+    });
+
     zipper.pipe(output);
     zipper.bulk([{ src: files, expand: true }]);
     zipper.finalize(function(err, bytes) {
-        if (err){
+        if (err) {
             defer.reject(err);
         }
-    });  
-    defer.resolve(archive);  
+    });
+
     return defer.promise;
 }
 

--- a/src/test/utilitytests.ts
+++ b/src/test/utilitytests.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/// <reference path="./definitions/mocha.d.ts"/>
+
+import assert = require('assert');
+import ccp = require('../agent/utilities');
+import testifm = require('vso-node-api/interfaces/TestInterfaces');
+import path = require('path');
+import fs = require('fs');
+var shell = require('shelljs');
+
+var file1 = path.resolve(__dirname, './testresults/xunitresults.xml');
+var file2 = path.resolve(__dirname, './codecoveragefiles/jacoco.xml');
+
+describe('UtiltyTests', function() {
+    it('archiveFiles : Archive files', function(done) {
+        this.timeout(2000);
+
+        ccp.archiveFiles([file1, file2], "test.zip").then(function(archive) {
+            var stats = fs.statSync(archive);
+            var fileSizeInBytes = stats["size"];
+            assert(fileSizeInBytes > 0);
+            done();
+        }).fail(function(err) {
+            assert(err);
+        });
+    })
+});	


### PR DESCRIPTION
Manual Testing done and verified.

Issue:
Archiving the files resolves the response before archive file is getting created which can cause corrputed archives.

Fix: Use file stream close call to resolve the response, which guarantees that file is closed and archive is completed