### PR TITLE
Publish code coverage task fix

### DIFF
--- a/src/agent/codecoveragepublisher.ts
+++ b/src/agent/codecoveragepublisher.ts
@@ -33,8 +33,8 @@ export class CodeCoveragePublisher {
     //-----------------------------------------------------
     // Publish code coverage
     //-----------------------------------------------------
-    public publishCodeCoverageSummary(): Q.Promise<boolean> {
-        var defer = Q.defer<boolean>();
+    public publishCodeCoverageSummary(): Q.Promise<any> {
+        var defer = Q.defer<any>();
         var _this = this;
         var summaryFile = _this.command.properties["summaryfile"];
 
@@ -43,7 +43,7 @@ export class CodeCoveragePublisher {
                 _this.executionContext.service.publishCodeCoverageSummary(codeCoverageData, _this.project, _this.buildId)
                     .then(function(result) {
                         _this.command.info("PublishCodeCoverageSummary : Code coverage summary published successfully.");
-                        defer.resolve(true);
+                        defer.resolve(null);
                     }).fail(function(error) {
                         _this.command.warning("PublishCodeCoverageSummary : Error occured while publishing code coverage summary. Error: " + error);
                         defer.reject(error);
@@ -51,7 +51,7 @@ export class CodeCoveragePublisher {
             }
             else {
                 _this.command.warning("PublishCodeCoverageSummary : No code coverage data found to publish.");
-                defer.resolve(false);
+                defer.resolve(null);
             }
         }).fail(function(err) {
             _this.command.warning("PublishCodeCoverageSummary : Error occured while reading code coverage summary. Error : " + err);

--- a/src/agent/commands/codecoverage.publish.ts
+++ b/src/agent/commands/codecoverage.publish.ts
@@ -66,17 +66,12 @@ export class CodeCoveragePublishCommand implements cm.IAsyncCommand {
         }
 
         var codeCoveragePublisher = new ccp.CodeCoveragePublisher(this.executionContext, this.command, reader);
-        codeCoveragePublisher.publishCodeCoverageSummary().then(function(codeCoveragePublished) {
-            if (codeCoveragePublished) {
-                codeCoveragePublisher.publishCodeCoverageFiles().then(function() {
-                    defer.resolve(true);
-                }).fail(function(error) {
-                    defer.reject(error);
-                });
-            }
-            else {
-                defer.resolve(false);
-            }
+        codeCoveragePublisher.publishCodeCoverageSummary().then(function() {
+            codeCoveragePublisher.publishCodeCoverageFiles().then(function() {
+                defer.resolve(true);
+            }).fail(function(error) {
+                defer.reject(error);
+            });
         }).fail(function(err) {
             defer.reject(err);
         });

--- a/src/test/publishcodecoveragetests.ts
+++ b/src/test/publishcodecoveragetests.ts
@@ -238,17 +238,18 @@ describe('CodeCoveragePublisherTests', function() {
     it('codecoverage.publish : publish jacoco summary when there is no code coverage data', function(done) {
         this.timeout(2000);
 
-        var properties: { [name: string]: string } = { "summaryfile": emptyJacocoSummaryFile, "codecoveragetool": "JaCoCo" };
+        var properties: { [name: string]: string } = { "summaryfile": emptyJacocoSummaryFile, "codecoveragetool": "JaCoCo", "reportdirectory": "", "additionalcodecoveragefiles": "" };
         var command: cm.ITaskCommand = new tc.TestCommand(null, null, null);
         command.properties = properties;
-        var jacocoSummaryReader = new csr.JacocoSummaryReader(command);
-        testExecutionContext = new tec.TestExecutionContext(new jobInf.TestJobInfo({}));
+        var jobInfo = new jobInf.TestJobInfo({});
+        jobInfo.variables = { "agent.workingDirectory": __dirname, "build.buildId": "1" };
+        testExecutionContext = new tec.TestExecutionContext(jobInfo);
 
         var codeCoveragePublishCommand = new cpc.CodeCoveragePublishCommand(testExecutionContext, command);
         codeCoveragePublishCommand.runCommandAsync().then(function(result) {
             assert(testExecutionContext.service.jobsCompletedSuccessfully(), 'CodeCoveragePublish Task Failed! Details : ' + testExecutionContext.service.getRecordsString());
-            assert(!result);
-            assert(testExecutionContext.service.containerItems.length == 0);
+            assert(result);
+            assert(testExecutionContext.service.containerItems.length == 1);
             done();
         },
             function(err) {
@@ -259,17 +260,18 @@ describe('CodeCoveragePublisherTests', function() {
     it('codecoverage.publish : publish cobertura summary when there is no code coverage data', function(done) {
         this.timeout(2000);
 
-        var properties: { [name: string]: string } = { "summaryfile": emptyCoberturaSummaryFile, "codecoveragetool": "cobertura" };
+        var properties: { [name: string]: string } = { "summaryfile": emptyCoberturaSummaryFile, "codecoveragetool": "cobertura", "reportdirectory": "", "additionalcodecoveragefiles": "" };
         var command: cm.ITaskCommand = new tc.TestCommand(null, null, null);
         command.properties = properties;
-        var coberturaSummaryReader = new csr.CoberturaSummaryReader(command);
-        testExecutionContext = new tec.TestExecutionContext(new jobInf.TestJobInfo({}));
+        var jobInfo = new jobInf.TestJobInfo({});
+        jobInfo.variables = { "agent.workingDirectory": __dirname, "build.buildId": "1" };
+        testExecutionContext = new tec.TestExecutionContext(jobInfo);
 
         var codeCoveragePublishCommand = new cpc.CodeCoveragePublishCommand(testExecutionContext, command);
         codeCoveragePublishCommand.runCommandAsync().then(function(result) {
             assert(testExecutionContext.service.jobsCompletedSuccessfully(), 'CodeCoveragePublish Task Failed! Details : ' + testExecutionContext.service.getRecordsString());
-            assert(!result);
-            assert(testExecutionContext.service.containerItems.length == 0);
+            assert(result);
+            assert(testExecutionContext.service.containerItems.length == 1);
             done();
         },
             function(err) {

--- a/src/test/publishcodecoveragetests.ts
+++ b/src/test/publishcodecoveragetests.ts
@@ -144,7 +144,6 @@ describe('CodeCoveragePublisherTests', function() {
         var codeCoveragePublisher = new ccp.CodeCoveragePublisher(testExecutionContext, command, jacocoSummaryReader);
         codeCoveragePublisher.publishCodeCoverageSummary().then(function(result) {
             assert(testExecutionContext.service.jobsCompletedSuccessfully(), 'CodeCoveragePublish Task Failed! Details : ' + testExecutionContext.service.getRecordsString());
-            assert(result);
             done();
         },
             function(err) {
@@ -187,7 +186,6 @@ describe('CodeCoveragePublisherTests', function() {
 
         codeCoveragePublisher.publishCodeCoverageSummary().then(function(result) {
             assert(testExecutionContext.service.jobsCompletedSuccessfully(), 'CodeCoveragePublish Task Failed! Details : ' + testExecutionContext.service.getRecordsString());
-            assert(result);
             done();
         },
             function(err) {


### PR DESCRIPTION
We were not pushing report directory when there is no code coverage data. But user might need it to check what is missing.
fixed it. 
Unit test changes accordingly.
Manual verification