### PR TITLE
Update onprem.md, changed http -> https for aka.ms

### DIFF
--- a/docs/onprem.md
+++ b/docs/onprem.md
@@ -39,7 +39,7 @@ From a terminal:
 mkdir myagent
 cd my agent
 
-curl -skSL http://aka.ms/xplatagent | bash
+curl -skSL https://aka.ms/xplatagent | bash
 ```
 Your output should look [similar to this](sampleoutput.md)
 
@@ -78,7 +78,7 @@ Before updating stop the agent (ctrl-c if interactive, if service [see run as a 
 
 From a terminal:
 ```bash
-curl -skSL http://aka.ms/xplatagent | bash
+curl -skSL https://aka.ms/xplatagent | bash
 ```
 Your output should look [similar to this](sampleoutput.md)
 


### PR DESCRIPTION
Changed http -> https.
aka.ms has SSL and running a downloaded bash script over http is just plain scary/dangerous.